### PR TITLE
Omit SCGContainerCallImage.Ref if empty

### DIFF
--- a/sdks/go/model/scg.go
+++ b/sdks/go/model/scg.go
@@ -32,7 +32,7 @@ type SCGContainerCall struct {
 
 type SCGContainerCallImage struct {
 	Src       *string       `json:"src,omitempty"`
-	Ref       string        `json:"ref"`
+	Ref       string        `json:"ref,omitempty"`
 	PullCreds *SCGPullCreds `json:"pullCreds,omitempty"`
 }
 

--- a/sdks/go/model/scg.go
+++ b/sdks/go/model/scg.go
@@ -32,7 +32,7 @@ type SCGContainerCall struct {
 
 type SCGContainerCallImage struct {
 	Src       *string       `json:"src,omitempty"`
-	Ref       string        `json:"ref,omitempty"`
+	Ref       *string        `json:"ref,omitempty"`
 	PullCreds *SCGPullCreds `json:"pullCreds,omitempty"`
 }
 


### PR DESCRIPTION
This fixes a bug if a opspec file is generated using `src` instead of `ref` for a container.

I found this when working on https://github.com/Remitly/infra-ops/tree/master/fpkg/run, looks like @psamaan may have manually patched this in vendored code 😬?