### PR TITLE
Add a github workflow to replace travis

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Build
 
 on:
   push:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,10 @@ jobs:
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
       id: branch_name
 
-    - uses: Remitly/opctl-action@e5d7594
+    - name: Download opctl
+      uses: jaxxstorm/action-install-gh-release@v1.1.0
       with:
-        # op: "-a gitBranch=${{ steps.branch_name.outputs.branch }} build"
-        op: build
+        repo: opctl/opctl
+        tag: v0.1.45
+
+    - run: opctl run -a gitBranch=${{ steps.branch_name.outputs.branch }} build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: opctl/opctl
-        version: latest
+        version: 0.1.45
         file: opctl0.1.45.linux.tgz
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,14 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
       
+    - name: Get branch ref
+      id: branch_ref
+      shell: bash
+      run: echo "##[set-output name=ref;]$(echo ${GITHUB_HEAD_REF-${GITHUB_REF}})"
+
     - name: Get branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF##*/})"
+      run: echo "##[set-output name=branch;]$(echo ${${{ steps.branch_ref.outputs.branch }}##*/-})"
       id: branch_name
 
     - name: Download opctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       
     - name: Get branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
       id: branch_name
 
     - name: Download opctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,5 +26,7 @@ jobs:
       with:
         repo: opctl/opctl
         tag: v0.1.45
+      env: 
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: opctl run -a gitBranch=${{ steps.branch_name.outputs.branch }} build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,16 +15,16 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2
-      
-    - name: Get branch ref
-      id: branch_ref
-      shell: bash
-      run: echo "##[set-output name=ref;]$(echo ${GITHUB_HEAD_REF-${GITHUB_REF}})"
 
-    - name: Get branch name
+    - name: Get branch name (push)
+      if: github.event_name != 'pull_request'
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${${{ steps.branch_ref.outputs.branch }}##*/-})"
-      id: branch_name
+      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
+
+    - name: Get branch name (pull_request)
+      if: github.event_name == 'pull_request'
+      shell: bash
+      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
 
     - name: Download opctl
       uses: dsaltares/fetch-gh-release-asset@0.0.5
@@ -37,4 +37,4 @@ jobs:
     - name: Extract opctl
       run: tar -xvzf opctl0.1.45.linux.tgz
 
-    - run: ./opctl run -a gitBranch=${{ steps.branch_name.outputs.branch }} build
+    - run: ./opctl run -a gitBranch=${{ env.BRANCH_NAME }} build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,4 +23,5 @@ jobs:
 
     - uses: Remitly/opctl-action@e5d7594
       with:
-        op: "-a gitBranch=${{ steps.branch_name.outputs.branch }} build"
+        # op: "-a gitBranch=${{ steps.branch_name.outputs.branch }} build"
+        op: build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,26 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      
+    - name: Get branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+      id: branch_name
+
+    - uses: Remitly/opctl-action@e5d7594
+      with:
+        op: "-a gitBranch=${{ steps.branch_name.outputs.branch }} build"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       id: branch_name
 
     - name: Download opctl
-      uses: dsaltares/fetch-gh-release-asset@v0.0.5
+      uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: opctl/opctl
         version: latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,11 +22,14 @@ jobs:
       id: branch_name
 
     - name: Download opctl
-      uses: jaxxstorm/action-install-gh-release@v1.1.0
+      uses: dsaltares/fetch-gh-release-asset@v0.0.5
       with:
         repo: opctl/opctl
-        tag: v0.1.45
-      env: 
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        version: latest
+        file: opctl0.1.45.linux.tgz
+        token: ${{ secrets.GITHUB_TOKEN }}
 
-    - run: opctl run -a gitBranch=${{ steps.branch_name.outputs.branch }} build
+    - name: Extract opctl
+      run: tar -xvzf opctl0.1.45.linux.tgz
+
+    - run: ./opctl run -a gitBranch=${{ steps.branch_name.outputs.branch }} build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
       uses: dsaltares/fetch-gh-release-asset@0.0.5
       with:
         repo: opctl/opctl
-        version: 0.1.45
+        version: tags/0.1.45
         file: opctl0.1.45.linux.tgz
         token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       
     - name: Get branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF##*/})"
       id: branch_name
 
     - name: Download opctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,12 +19,14 @@ jobs:
     - name: Get branch name (push)
       if: github.event_name != 'pull_request'
       shell: bash
-      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_REF#refs/heads/})"
+      id: branch_name_push
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
 
     - name: Get branch name (pull_request)
       if: github.event_name == 'pull_request'
       shell: bash
-      run: echo "::set-env name=BRANCH_NAME::$(echo ${GITHUB_HEAD_REF})"
+      id: branch_name_pr
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
 
     - name: Download opctl
       uses: dsaltares/fetch-gh-release-asset@0.0.5
@@ -37,4 +39,4 @@ jobs:
     - name: Extract opctl
       run: tar -xvzf opctl0.1.45.linux.tgz
 
-    - run: ./opctl run -a gitBranch=${{ env.BRANCH_NAME }} build
+    - run: ./opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: generic
-sudo: required
-before_script:
-- curl -L https://bin.equinox.io/c/5Sox3KYDRTV/opctl-alpha-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
-services:
-- docker
-script:
-- opctl run -a gitBranch=$TRAVIS_BRANCH build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/opctl/opctl.svg?branch=master)](https://travis-ci.org/opctl/opctl)
+[![Build](https://github.com/opctl/opctl/workflows/Build/badge.svg)](https://github.com/opctl/opctl/actions?query=workflow%3ABuild)
 [![Go Report Card](https://goreportcard.com/badge/github.com/opctl/opctl)](https://goreportcard.com/report/github.com/opctl/opctl)
 [![Coverage](https://codecov.io/gh/opctl/opctl/branch/master/graph/badge.svg)](https://codecov.io/gh/opctl/opctl)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build](https://github.com/opctl/opctl/workflows/Build/badge.svg)](https://github.com/opctl/opctl/actions?query=workflow%3ABuild)
+[![Build](https://github.com/opctl/opctl/workflows/Build/badge.svg)](https://github.com/opctl/opctl/actions?query=workflow%3ABuild+branch%3Agithub-actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/opctl/opctl)](https://goreportcard.com/report/github.com/opctl/opctl)
 [![Coverage](https://codecov.io/gh/opctl/opctl/branch/master/graph/badge.svg)](https://codecov.io/gh/opctl/opctl)
 


### PR DESCRIPTION
Travis open source is [end of life](https://docs.travis-ci.com/user/migrate/open-source-repository-migration/#frequently-asked-questions) and has severely throttled availability of executors, which makes builds really slow. This replaces travis builds with a github actions workflow