### PR TITLE
Fix docker container removal

### DIFF
--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
@@ -13,7 +13,7 @@ func (ctp _containerRuntime) DeleteContainerIfExists(
 ) error {
 	err := ctp.dockerClient.ContainerRemove(
 		ctx,
-		containerID,
+		fmt.Sprintf("opctl_%s", containerID),
 		types.ContainerRemoveOptions{
 			RemoveVolumes: true,
 			Force:         true,

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
@@ -13,7 +13,7 @@ func (ctp _containerRuntime) DeleteContainerIfExists(
 ) error {
 	err := ctp.dockerClient.ContainerRemove(
 		ctx,
-		fmt.Sprintf("opctl_%s", containerID),
+		getContainerName(containerID),
 		types.ContainerRemoveOptions{
 			RemoveVolumes: true,
 			Force:         true,

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
@@ -18,7 +18,7 @@ var _ = Context("DeleteContainerIfExists", func() {
 
 		providedCtx := context.Background()
 		providedContainerName := "dummyContainerName"
-		expectedContainerName := providedContainerName
+		expectedContainerName := "opctl_" + providedContainerName
 		expectedContainerRemoveOptions := types.ContainerRemoveOptions{
 			RemoveVolumes: true,
 			Force:         true,

--- a/sdks/go/node/core/containerruntime/docker/getContainerName.go
+++ b/sdks/go/node/core/containerruntime/docker/getContainerName.go
@@ -1,0 +1,7 @@
+package docker
+
+import "fmt"
+
+func getContainerName(opctlContainerID string) string {
+	return fmt.Sprintf("opctl_%s", opctlContainerID)
+}

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -79,7 +79,7 @@ func (cr _runContainer) RunContainer(
 
 	// for docker, we prefix name with opctl_ in order to allow external tools to know it's an opctl managed container
 	// do not change this prefix as it might break external consumers
-	containerName := fmt.Sprintf("opctl_%s", req.ContainerID)
+	containerName := getContainerName(req.ContainerID)
 	defer func() {
 		// ensure container always cleaned up
 		cr.dockerClient.ContainerRemove(


### PR DESCRIPTION
#736 changed the name opctl assigns to docker containers, but it didn't update the teardown code, which can result in a docker container remaining alive after opctl stops tracking it. If ports are bound, this will cause the next op run to fail.