### PR TITLE
Delete accidentally committed binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 
 ### build
 /cli/opctl.*
+/opctl.*


### PR DESCRIPTION
Also, update the gitignore to prevent this. I've left the cli line in the gitignore in case people have old binaries hanging around.