### PR TITLE
Emit CallStarted events for skipped conditional branches

### DIFF
--- a/cli/internal/clioutput/cliOutput.go
+++ b/cli/internal/clioutput/cliOutput.go
@@ -152,7 +152,7 @@ func (this _cliOutput) containerExited(event *model.Event) {
 	switch event.CallEnded.Outcome {
 	case model.OpOutcomeSucceeded:
 		this.Success(message)
-	case model.OpOutcomeKilled, model.OpOutcomeSkipped:
+	case model.OpOutcomeKilled:
 		this.Info(message)
 	default:
 		this.Error(message)
@@ -200,7 +200,7 @@ func (this _cliOutput) opEnded(event *model.Event) {
 	switch event.CallEnded.Outcome {
 	case model.OpOutcomeSucceeded:
 		this.Success(message)
-	case model.OpOutcomeKilled, model.OpOutcomeSkipped:
+	case model.OpOutcomeKilled:
 		this.Info(message)
 	default:
 		this.Error(message)

--- a/cli/internal/clioutput/cliOutput.go
+++ b/cli/internal/clioutput/cliOutput.go
@@ -152,7 +152,7 @@ func (this _cliOutput) containerExited(event *model.Event) {
 	switch event.CallEnded.Outcome {
 	case model.OpOutcomeSucceeded:
 		this.Success(message)
-	case model.OpOutcomeKilled:
+	case model.OpOutcomeKilled, model.OpOutcomeSkipped:
 		this.Info(message)
 	default:
 		this.Error(message)
@@ -200,7 +200,7 @@ func (this _cliOutput) opEnded(event *model.Event) {
 	switch event.CallEnded.Outcome {
 	case model.OpOutcomeSucceeded:
 		this.Success(message)
-	case model.OpOutcomeKilled:
+	case model.OpOutcomeKilled, model.OpOutcomeSkipped:
 		this.Info(message)
 	default:
 		this.Error(message)

--- a/cli/internal/core/runer.go
+++ b/cli/internal/core/runer.go
@@ -192,17 +192,17 @@ func (ivkr _runer) Run(
 
 			ivkr.cliOutput.Event(&event)
 
-			if nil != event.CallEnded {
-				if event.CallEnded.Call.ID == rootCallID {
-					switch event.CallEnded.Outcome {
-					case model.OpOutcomeSucceeded, model.OpOutcomeSkipped:
-						return nil
-					case model.OpOutcomeKilled:
-						return &RunError{ExitCode: 137}
-					default:
-						return &RunError{ExitCode: 1}
-					}
+			if nil != event.CallEnded && event.CallEnded.Call.ID == rootCallID {
+				switch event.CallEnded.Outcome {
+				case model.OpOutcomeSucceeded:
+					return nil
+				case model.OpOutcomeKilled:
+					return &RunError{ExitCode: 137}
+				default:
+					return &RunError{ExitCode: 1}
 				}
+			} else if nil != event.CallSkipped && event.CallSkipped.Call.ID == rootCallID {
+				return &RunError{ExitCode: 1}
 			}
 		}
 

--- a/cli/internal/core/runer.go
+++ b/cli/internal/core/runer.go
@@ -195,7 +195,7 @@ func (ivkr _runer) Run(
 			if nil != event.CallEnded {
 				if event.CallEnded.Call.ID == rootCallID {
 					switch event.CallEnded.Outcome {
-					case model.OpOutcomeSucceeded:
+					case model.OpOutcomeSucceeded, model.OpOutcomeSkipped:
 						return nil
 					case model.OpOutcomeKilled:
 						return &RunError{ExitCode: 137}

--- a/sdks/go/model/event.go
+++ b/sdks/go/model/event.go
@@ -15,6 +15,7 @@ type Event struct {
 
 const (
 	OpOutcomeSucceeded = "SUCCEEDED"
+	OpOutcomeSkipped   = "SKIPPED"
 	OpOutcomeFailed    = "FAILED"
 	OpOutcomeKilled    = "KILLED"
 )

--- a/sdks/go/model/event.go
+++ b/sdks/go/model/event.go
@@ -7,6 +7,7 @@ type Event struct {
 	AuthAdded                *AuthAdded                `json:"authAdded,omitempty"`
 	CallEnded                *CallEnded                `json:"callEnded,omitempty"`
 	CallStarted              *CallStarted              `json:"callStarted,omitempty"`
+	CallSkipped              *CallSkipped              `json:"callSkipped,omitempty"`
 	ContainerStdErrWrittenTo *ContainerStdErrWrittenTo `json:"containerStdErrWrittenTo,omitempty"`
 	ContainerStdOutWrittenTo *ContainerStdOutWrittenTo `json:"containerStdOutWrittenTo,omitempty"`
 	CallKillRequested        *CallKillRequested        `json:"callKillRequested,omitempty"`
@@ -15,7 +16,6 @@ type Event struct {
 
 const (
 	OpOutcomeSucceeded = "SUCCEEDED"
-	OpOutcomeSkipped   = "SKIPPED"
 	OpOutcomeFailed    = "FAILED"
 	OpOutcomeKilled    = "KILLED"
 )
@@ -44,6 +44,9 @@ type CallStarted struct {
 	Call Call   `json:"call"`
 	Ref  string `json:"ref"`
 }
+
+// CallSkipped represents an op that was skipped
+type CallSkipped = CallStarted
 
 // CallEndedError represents an error associated w/ an ended call
 type CallEndedError struct {

--- a/sdks/go/node/core/caller.go
+++ b/sdks/go/node/core/caller.go
@@ -148,9 +148,6 @@ func (clr _caller) Call(
 		if isKilled || nil != ctx.Err() {
 			// this call or parent call killed/cancelled
 			event.CallEnded.Outcome = model.OpOutcomeKilled
-			event.CallEnded.Error = &model.CallEndedError{
-				Message: ctx.Err().Error(),
-			}
 		} else if nil != err {
 			event.CallEnded.Outcome = model.OpOutcomeFailed
 			event.CallEnded.Error = &model.CallEndedError{

--- a/sdks/go/node/core/caller.go
+++ b/sdks/go/node/core/caller.go
@@ -160,8 +160,8 @@ func (clr _caller) Call(
 		clr.pubSub.Publish(event)
 	}()
 
-	// Ensure this is emitted just after the deferred operation to emit the end
-	// event is set up, so we always have a matching start and end event
+	// Emit start event just after the deferred operation to emit the end event is
+	// set up, so we always have a matching start and end event
 	clr.pubSub.Publish(
 		model.Event{
 			Timestamp: callStartTime,

--- a/sdks/go/node/core/caller.go
+++ b/sdks/go/node/core/caller.go
@@ -180,16 +180,6 @@ func (clr _caller) Call(
 		return outputs, err
 	}
 
-	clr.pubSub.Publish(
-		model.Event{
-			Timestamp: callStartTime,
-			CallStarted: &model.CallStarted{
-				Call: *call,
-				Ref:  opPath,
-			},
-		},
-	)
-
 	go func() {
 		defer func() {
 			if panicArg := recover(); panicArg != nil {

--- a/sdks/go/node/core/caller_test.go
+++ b/sdks/go/node/core/caller_test.go
@@ -614,7 +614,7 @@ var _ = Context("caller", func() {
 				/* assert */
 				Expect(fakeSerialLoopCaller.CallCallCount()).To(Equal(0))
 
-				// Emits both a start and end event
+				// Emits a skip event
 				Expect(fakePubSub.PublishCallCount()).To(Equal(1))
 				ifValue := false
 				actualEvent1 := fakePubSub.PublishArgsForCall(0)

--- a/sdks/go/node/core/caller_test.go
+++ b/sdks/go/node/core/caller_test.go
@@ -615,11 +615,11 @@ var _ = Context("caller", func() {
 				Expect(fakeSerialLoopCaller.CallCallCount()).To(Equal(0))
 
 				// Emits both a start and end event
-				Expect(fakePubSub.PublishCallCount()).To(Equal(2))
+				Expect(fakePubSub.PublishCallCount()).To(Equal(1))
 				ifValue := false
 				actualEvent1 := fakePubSub.PublishArgsForCall(0)
 				Expect(actualEvent1).To(Equal(model.Event{
-					CallStarted: &model.CallStarted{
+					CallSkipped: &model.CallSkipped{
 						Call: model.Call{
 							ID:       providedCallID,
 							If:       &ifValue,
@@ -629,20 +629,6 @@ var _ = Context("caller", func() {
 						Ref: providedOpPath,
 					},
 					Timestamp: actualEvent1.Timestamp,
-				}))
-				actualEvent2 := fakePubSub.PublishArgsForCall(1)
-				Expect(actualEvent2).To(Equal(model.Event{
-					CallEnded: &model.CallEnded{
-						Call: model.Call{
-							ID:       providedCallID,
-							If:       &ifValue,
-							ParentID: &providedParentID,
-							RootID:   providedRootCallID,
-						},
-						Ref:     providedOpPath,
-						Outcome: model.OpOutcomeSkipped,
-					},
-					Timestamp: actualEvent2.Timestamp,
 				}))
 			})
 		})


### PR DESCRIPTION
Currently, a call ended event is emitted when a skipped if conditional branch call is processed without a start event. This means that anything watching the events stream will receive an ended event without a corresponding start event, and won't know how to deal with it.

I've introduced a new outcome type: "skipped", to indicate when this happens. Alternatively, failed if conditional could be not outputted at all, but that would mean anything listening to the event stream wouldn't know about them at all, which limits the user experience.