### PR TITLE
Ensure UI uses the correct listen address

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -318,7 +318,8 @@ func newCli(
 				"Opctl web UI opened!",
 				ui(
 					cliParamSatisfier,
-					nodeProvider,
+          nodeProvider,
+          *listenAddress,
 					*mountRefArg,
 				),
 			)

--- a/cli/ui.go
+++ b/cli/ui.go
@@ -14,7 +14,8 @@ import (
 // ui implements "ui" command
 func ui(
 	cliParamSatisfier cliparamsatisfier.CLIParamSatisfier,
-	nodeProvider nodeprovider.NodeProvider,
+  nodeProvider nodeprovider.NodeProvider,
+  listenAddress string,
 	mountRefArg string,
 ) error {
 	var resolvedMount string
@@ -49,6 +50,6 @@ func ui(
 	}
 
 	return open.Run(
-		fmt.Sprintf("http://localhost:42224?mount=%s", url.QueryEscape(resolvedMount)),
+    fmt.Sprintf("http://%s/?mount=%s", listenAddress, url.QueryEscape(resolvedMount)),
 	)
 }


### PR DESCRIPTION
Currently, the UI uses a hardcoded `localhost:42224`, instead of the provided cli argument listen address.