### PR TITLE
Pass context throughout call paths where possible

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,6 +29,21 @@
             "request": "launch",
             "mode": "test",
             "program": "${file}"
+        },
+        {
+            "name": "Run and debug an opctl node",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cli",
+            "args": [
+                "--data-dir",
+                "${workspaceFolder}/debug-data-dir",
+                "--listen-address",
+                "127.0.0.1:42224",
+                "node",
+                "create"
+            ]
         }
     ]
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -105,6 +105,12 @@ func newCli(
 		if *noColor {
 			cliOutput.DisableColor()
 		}
+  }	
+  
+  ctx, cancel := context.WithCancel(context.Background())
+
+	cli.After = func() {
+		cancel()
 	}
 
 	cli.Command("auth", "Manage auth for OCI image registries", func(authCmd *mow.Cmd) {
@@ -119,7 +125,7 @@ func newCli(
 				exitWith(
 					"",
 					auth(
-						context.TODO(),
+						ctx,
 						nodeProvider,
 						model.AddAuthReq{
 							Resources: *resources,
@@ -139,7 +145,7 @@ func newCli(
 			exitWith(
 				"",
 				events(
-					context.TODO(),
+					ctx,
 					cliOutput,
 					nodeProvider,
 				),
@@ -156,7 +162,7 @@ func newCli(
 			exitWith(
 				"",
 				ls(
-					context.TODO(),
+					ctx,
 					cliParamSatisfier,
 					nodeProvider,
 					*dirRef,
@@ -170,7 +176,10 @@ func newCli(
 			createCmd.Action = func() {
 				exitWith(
 					"",
-					node(nodeCreateOpts),
+					node(
+            ctx,
+            nodeCreateOpts,
+          ),
 				)
 			}
 		})
@@ -220,7 +229,7 @@ func newCli(
 				exitWith(
 					"",
 					opInstall(
-						context.TODO(),
+						ctx,
 						dataResolver,
 						*opRef,
 						*path,
@@ -240,7 +249,7 @@ func newCli(
 				exitWith(
 					"",
 					node.KillOp(
-						context.TODO(),
+						ctx,
 						model.KillOpReq{
 							OpID:       *opID,
 							RootCallID: *opID,
@@ -257,7 +266,7 @@ func newCli(
 				exitWith(
 					fmt.Sprintf("%v is valid", *opRef),
 					opValidate(
-						context.TODO(),
+						ctx,
 						dataResolver,
 						*opRef,
 					),
@@ -275,7 +284,7 @@ func newCli(
 			exitWith(
 				"",
 				run(
-					context.TODO(),
+					ctx,
 					cliOutput,
 					cliParamSatisfier,
 					nodeProvider,

--- a/cli/httpListener.go
+++ b/cli/httpListener.go
@@ -80,7 +80,7 @@ func (hd _httpListener) listen(
 
 	go func() {
 		<-done
-		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, _ := context.WithTimeout(ctx, 5*time.Second)
 
 		// little hammer
 		httpServer.Shutdown(ctx)

--- a/cli/node.go
+++ b/cli/node.go
@@ -12,6 +12,7 @@ import (
 
 // node command
 func node(
+  ctx context.Context,
 	nodeCreateOpts local.NodeCreateOpts,
 ) error {
 	dataDir, err := datadir.New(nodeCreateOpts.DataDir)
@@ -30,7 +31,7 @@ func node(
 			return err
 		}
 	} else {
-		containerRuntime, err = docker.New()
+		containerRuntime, err = docker.New(ctx)
 		if nil != err {
 			return err
 		}
@@ -38,12 +39,13 @@ func node(
 
 	return newHTTPListener(
 		core.New(
+      ctx,
 			containerRuntime,
 			dataDir.Path(),
 		),
 	).
 		listen(
-			context.Background(),
+			ctx,
 			nodeCreateOpts.ListenAddress,
 		)
 

--- a/sdks/go/node/api/client/auths_adds.go
+++ b/sdks/go/node/api/client/auths_adds.go
@@ -26,7 +26,8 @@ func (c apiClient) AddAuth(
 	reqURL := c.baseURL
 	reqURL.Path = path.Join(reqURL.Path, api.URLAuths_Adds)
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"POST",
 		reqURL.String(),
 		bytes.NewBuffer(reqBytes),
@@ -34,8 +35,6 @@ func (c apiClient) AddAuth(
 	if nil != err {
 		return err
 	}
-
-	httpReq = httpReq.WithContext(ctx)
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if nil != err {

--- a/sdks/go/node/api/client/liveness.go
+++ b/sdks/go/node/api/client/liveness.go
@@ -13,7 +13,8 @@ func (c apiClient) Liveness(
 	ctx context.Context,
 ) error {
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"GET",
 		c.baseURL.String()+api.URLLiveness,
 		nil,
@@ -21,8 +22,6 @@ func (c apiClient) Liveness(
 	if nil != err {
 		return err
 	}
-
-	httpReq = httpReq.WithContext(ctx)
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if nil != err {

--- a/sdks/go/node/api/client/ops_kills.go
+++ b/sdks/go/node/api/client/ops_kills.go
@@ -26,7 +26,8 @@ func (c apiClient) KillOp(
 	reqURL := c.baseURL
 	reqURL.Path = path.Join(reqURL.Path, api.URLOps_Kills)
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"POST",
 		reqURL.String(),
 		bytes.NewBuffer(reqBytes),
@@ -34,8 +35,6 @@ func (c apiClient) KillOp(
 	if nil != err {
 		return err
 	}
-
-	httpReq = httpReq.WithContext(ctx)
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if nil != err {

--- a/sdks/go/node/api/client/ops_starts.go
+++ b/sdks/go/node/api/client/ops_starts.go
@@ -27,7 +27,8 @@ func (c apiClient) StartOp(
 	reqURL := c.baseURL
 	reqURL.Path = path.Join(reqURL.Path, api.URLOps_Starts)
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"POST",
 		reqURL.String(),
 		bytes.NewBuffer(reqBytes),
@@ -35,8 +36,6 @@ func (c apiClient) StartOp(
 	if nil != err {
 		return "", err
 	}
-
-	httpReq = httpReq.WithContext(ctx)
 
 	httpResp, err := c.httpClient.Do(httpReq)
 	if nil != err {

--- a/sdks/go/node/api/client/pkgs_ref_contents.go
+++ b/sdks/go/node/api/client/pkgs_ref_contents.go
@@ -25,7 +25,8 @@ func (c apiClient) ListDescendants(
 	// build url
 	path := strings.Replace(api.URLPkgs_Ref_Contents, "{ref}", url.PathEscape(req.PkgRef), 1)
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"GET",
 		c.baseURL.String()+path,
 		nil,
@@ -34,7 +35,6 @@ func (c apiClient) ListDescendants(
 		return nil, err
 	}
 
-	httpReq = httpReq.WithContext(ctx)
 	if nil != req.PullCreds {
 		httpReq.SetBasicAuth(
 			req.PullCreds.Username,

--- a/sdks/go/node/api/client/pkgs_ref_contents_path.go
+++ b/sdks/go/node/api/client/pkgs_ref_contents_path.go
@@ -26,7 +26,8 @@ func (c apiClient) GetData(
 	path := strings.Replace(api.URLPkgs_Ref_Contents_Path, "{ref}", url.PathEscape(req.PkgRef), 1)
 	path = strings.Replace(path, "{path}", url.PathEscape(req.ContentPath), 1)
 
-	httpReq, err := http.NewRequest(
+	httpReq, err := http.NewRequestWithContext(
+		ctx,
 		"GET",
 		c.baseURL.String()+path,
 		nil,
@@ -35,7 +36,6 @@ func (c apiClient) GetData(
 		return nil, err
 	}
 
-	httpReq = httpReq.WithContext(ctx)
 	if nil != req.PullCreds {
 		httpReq.SetBasicAuth(
 			req.PullCreds.Username,

--- a/sdks/go/node/api/handler/ops/starts/handler.go
+++ b/sdks/go/node/api/handler/ops/starts/handler.go
@@ -3,6 +3,7 @@ package starts
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -44,8 +45,11 @@ func (hdlr _handler) Handle(
 		return
 	}
 
+	// This uses a fresh context because the running op continues running
+	// after the http request closes
+	ctx := context.Background()
 	callID, err := hdlr.node.StartOp(
-		httpReq.Context(),
+		ctx,
 		startOpReq,
 	)
 	if nil != err {

--- a/sdks/go/node/core/addAuth.go
+++ b/sdks/go/node/core/addAuth.go
@@ -11,7 +11,6 @@ func (this core) AddAuth(
 	ctx context.Context,
 	req model.AddAuthReq,
 ) error {
-	// killing an op is async
 	this.pubSub.Publish(
 		model.Event{
 			AuthAdded: &model.AuthAdded{

--- a/sdks/go/node/core/callKiller_test.go
+++ b/sdks/go/node/core/callKiller_test.go
@@ -48,7 +48,7 @@ var _ = Context("_callKiller", func() {
 					panic(err)
 				}
 
-				stateStore := newStateStore(db, pubSub)
+				stateStore := newStateStore(context.Background(), db, pubSub)
 
 				// seed call
 				pubSub.Publish(model.Event{
@@ -75,7 +75,7 @@ var _ = Context("_callKiller", func() {
 					})
 				}
 
-				// give stateStore time to receive & apply start events
+				// give stateStore time to receive & apply events
 				time.Sleep(time.Second)
 
 				objectUnderTest := newCallKiller(

--- a/sdks/go/node/core/caller.go
+++ b/sdks/go/node/core/caller.go
@@ -143,6 +143,7 @@ func (clr _caller) Call(
 	}
 
 	call, err = callpkg.Interpret(
+		ctx,
 		scope,
 		callSpec,
 		id,

--- a/sdks/go/node/core/containerCaller_test.go
+++ b/sdks/go/node/core/containerCaller_test.go
@@ -38,7 +38,7 @@ var _ = Context("containerCaller", func() {
 			Expect(newContainerCaller(
 				new(FakeContainerRuntime),
 				new(FakePubSub),
-				newStateStore(db, new(FakePubSub)),
+				newStateStore(context.Background(), db, new(FakePubSub)),
 			)).To(Not(BeNil()))
 		})
 	})

--- a/sdks/go/node/core/containerruntime/docker/containerRuntime.go
+++ b/sdks/go/node/core/containerruntime/docker/containerRuntime.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func New() (
+func New(ctx context.Context) (
 	containerRuntime containerruntime.ContainerRuntime,
 	err error,
 ) {
@@ -21,9 +21,9 @@ func New() (
 	}
 
 	// degrade client version to version of server
-	dockerClient.NegotiateAPIVersion(context.TODO())
+	dockerClient.NegotiateAPIVersion(ctx)
 
-	rc, err := newRunContainer(dockerClient)
+	rc, err := newRunContainer(ctx, dockerClient)
 	if nil != err {
 		return
 	}

--- a/sdks/go/node/core/containerruntime/docker/fsPathConverter.go
+++ b/sdks/go/node/core/containerruntime/docker/fsPathConverter.go
@@ -1,13 +1,15 @@
 package docker
 
 import (
+	"context"
+	"path"
+	"regexp"
+	"strings"
+
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/opctl/opctl/sdks/go/internal/iruntime"
 	"github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/hostruntime"
 	"github.com/pkg/errors"
-	"path"
-	"regexp"
-	"strings"
 )
 
 //counterfeiter:generate -o internal/fakes/fsPathConverter.go . fsPathConverter
@@ -16,9 +18,10 @@ type fsPathConverter interface {
 }
 
 func newFSPathConverter(
+	ctx context.Context,
 	dockerClient dockerClientPkg.CommonAPIClient,
 ) (fsPathConverter, error) {
-	hr, err := hostruntime.New(dockerClient)
+	hr, err := hostruntime.New(ctx, dockerClient)
 	if err != nil {
 		return _fsPathConverter{}, errors.Wrap(err, "error detecting docker host runtime")
 	}

--- a/sdks/go/node/core/containerruntime/docker/hostConfigFactory.go
+++ b/sdks/go/node/core/containerruntime/docker/hostConfigFactory.go
@@ -1,11 +1,13 @@
 package docker
 
 import (
+	"context"
+	"strings"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
-	"strings"
 )
 
 //counterfeiter:generate -o internal/fakes/hostConfigFactory.go . hostConfigFactory
@@ -19,9 +21,10 @@ type hostConfigFactory interface {
 }
 
 func newHostConfigFactory(
+	ctx context.Context,
 	dockerClient dockerClientPkg.CommonAPIClient,
 ) (hostConfigFactory, error) {
-	fspc, err := newFSPathConverter(dockerClient)
+	fspc, err := newFSPathConverter(ctx, dockerClient)
 	if err != nil {
 		return _hostConfigFactory{}, err
 	}

--- a/sdks/go/node/core/containerruntime/docker/hostruntime/runtimeinfo.go
+++ b/sdks/go/node/core/containerruntime/docker/hostruntime/runtimeinfo.go
@@ -2,10 +2,11 @@ package hostruntime
 
 import (
 	"context"
+	"time"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // RuntimeInfo provides relation between opctl and docker engine host
@@ -18,9 +19,9 @@ type RuntimeInfo struct {
 	HostPathMap HostPathMap
 }
 
-func New(cli containerInspector) (RuntimeInfo, error) {
-	ctx, _ := context.WithTimeout(context.Background(), 3*time.Second)
-	return newContainerRuntimeInfo(ctx, cli, defaultContainerUtils)
+func New(ctx context.Context, cli containerInspector) (RuntimeInfo, error) {
+	timeoutCtx, _ := context.WithTimeout(ctx, 3*time.Second)
+	return newContainerRuntimeInfo(timeoutCtx, cli, defaultContainerUtils)
 }
 
 func newContainerRuntimeInfo(ctx context.Context, cli containerInspector, cu containerUtils) (RuntimeInfo, error) {

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -28,9 +28,10 @@ type runContainer interface {
 }
 
 func newRunContainer(
+	ctx context.Context,
 	dockerClient dockerClientPkg.CommonAPIClient,
 ) (runContainer, error) {
-	hcf, err := newHostConfigFactory(dockerClient)
+	hcf, err := newHostConfigFactory(ctx, dockerClient)
 	if err != nil {
 		return _runContainer{}, err
 	}
@@ -83,7 +84,7 @@ func (cr _runContainer) RunContainer(
 	defer func() {
 		// ensure container always cleaned up
 		cr.dockerClient.ContainerRemove(
-			context.Background(),
+			context.Background(), // always use a fresh context, to clean up after cancellation
 			containerName,
 			types.ContainerRemoveOptions{
 				RemoveVolumes: true,

--- a/sdks/go/node/core/containerruntime/k8s/containerRuntime.go
+++ b/sdks/go/node/core/containerruntime/k8s/containerRuntime.go
@@ -43,7 +43,7 @@ func (cr _containerRuntime) DeleteContainerIfExists(
 	containerID string,
 ) error {
 	err := cr.k8sClient.CoreV1().Pods("opctl").Delete(
-		context.TODO(),
+		ctx,
 		constructPodName(containerID),
 		metaV1.DeleteOptions{},
 	)
@@ -129,7 +129,7 @@ func (cr _containerRuntime) RunContainer(
 					Follow: true,
 				},
 			)
-			logSrc, err := logsResult.Stream(context.TODO())
+			logSrc, err := logsResult.Stream(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("running, LogStreamError %s", err)
 			}

--- a/sdks/go/node/core/core.go
+++ b/sdks/go/node/core/core.go
@@ -21,6 +21,7 @@ import (
 
 // New returns a new LocalCore initialized with the given options
 func New(
+	ctx context.Context,
 	containerRuntime containerruntime.ContainerRuntime,
 	dataDirPath string,
 ) Core {
@@ -47,6 +48,7 @@ func New(
 	uniqueStringFactory := uniquestring.NewUniqueStringFactory()
 
 	stateStore := newStateStore(
+		ctx,
 		db,
 		pubSub,
 	)
@@ -68,8 +70,6 @@ func New(
 			containerRuntime,
 			pubSub,
 		)
-
-		ctx := context.Background()
 
 		since := time.Now().UTC()
 		eventChannel, _ := pubSub.Subscribe(

--- a/sdks/go/node/core/core_test.go
+++ b/sdks/go/node/core/core_test.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"context"
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/opctl/opctl/sdks/go/node/core/containerruntime/fakes"
-	"os"
 )
 
 var _ = Context("core", func() {
@@ -13,6 +15,7 @@ var _ = Context("core", func() {
 			/* arrange/act/assert */
 			Expect(
 				New(
+					context.Background(),
 					new(FakeContainerRuntime),
 					os.TempDir(),
 				),

--- a/sdks/go/node/core/startOp.go
+++ b/sdks/go/node/core/startOp.go
@@ -64,7 +64,7 @@ func (this core) StartOp(
 		opCallSpec.Outputs[name] = ""
 	}
 
-	opCtx, cancelOp := context.WithCancel(context.Background())
+	opCtx, cancelOp := context.WithCancel(ctx)
 	go func() {
 		defer func() {
 			if panicArg := recover(); panicArg != nil {

--- a/sdks/go/node/core/stateStore.go
+++ b/sdks/go/node/core/stateStore.go
@@ -31,6 +31,7 @@ type stateStore interface {
 }
 
 func newStateStore(
+	ctx context.Context,
 	db *badger.DB,
 	pubSub pubsub.PubSub,
 ) stateStore {
@@ -53,7 +54,7 @@ func newStateStore(
 		since := lastAppliedEventTimestamp.Add(-time.Second)
 
 		eventChannel, _ := pubSub.Subscribe(
-			context.Background(),
+			ctx,
 			model.EventFilter{
 				Since: &since,
 			},

--- a/sdks/go/node/core/stateStore_test.go
+++ b/sdks/go/node/core/stateStore_test.go
@@ -1,0 +1,94 @@
+package core
+
+import (
+	"context"
+	"github.com/dgraph-io/badger/v2"
+	"io/ioutil"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/pubsub"
+)
+
+var _ = Context("stateStore", func() {
+	Context("TryGetAuth", func() {
+		Context("AuthAdded", func() {
+			It("should return expected auth", func() {
+
+				/* arrange */
+				providedReq := model.AddAuthReq{
+					Creds: model.Creds{
+						Username: "username",
+						Password: "password",
+					},
+					Resources: "resources",
+				}
+
+				dbDir, err := ioutil.TempDir("", "")
+				if nil != err {
+					panic(err)
+				}
+
+				db, err := badger.Open(
+					badger.DefaultOptions(dbDir).WithLogger(nil),
+				)
+				if nil != err {
+					panic(err)
+				}
+
+				pubSub := pubsub.New(db)
+				eventChannel, err := pubSub.Subscribe(
+					context.Background(),
+					model.EventFilter{},
+				)
+				if nil != err {
+					panic(err)
+				}
+
+				expectedAuth := model.Auth{
+					Creds:     providedReq.Creds,
+					Resources: providedReq.Resources,
+				}
+				// seed auth
+				pubSub.Publish(model.Event{
+					AuthAdded: &model.AuthAdded{
+						Auth: expectedAuth,
+					},
+					Timestamp: time.Now().UTC(),
+				})
+
+				objectUnderTest := newStateStore(
+					context.Background(),
+					db,
+					pubSub,
+				)
+
+				// give stateStore time to receive & apply events
+				time.Sleep(time.Second)
+
+				/* act */
+				objectUnderTest.TryGetAuth(
+					expectedAuth.Resources,
+				)
+
+				/* assert */
+				var actualAuth model.Auth
+				go func() {
+					for event := range eventChannel {
+						if nil != event.AuthAdded {
+							actualAuth = event.AuthAdded.Auth
+						}
+					}
+				}()
+
+				Eventually(
+					func() model.Auth { return actualAuth },
+				).Should(
+					Equal(expectedAuth),
+				)
+			})
+		})
+	})
+})

--- a/sdks/go/opspec/interpreter/call/interpret.go
+++ b/sdks/go/opspec/interpreter/call/interpret.go
@@ -1,6 +1,7 @@
 package call
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/opctl/opctl/sdks/go/model"
@@ -13,6 +14,7 @@ import (
 
 //Interpret a spec into a call
 func Interpret(
+	ctx context.Context,
 	scope map[string]*model.Value,
 	callSpec *model.CallSpec,
 	id string,
@@ -59,6 +61,7 @@ func Interpret(
 		return call, err
 	case nil != callSpec.Op:
 		call.Op, err = op.Interpret(
+			ctx,
 			scope,
 			callSpec.Op,
 			id,

--- a/sdks/go/opspec/interpreter/call/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/interpret_test.go
@@ -1,6 +1,7 @@
 package call
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -17,12 +18,11 @@ var _ = Context("Interpret", func() {
 		Context("predicates returns err", func() {
 			It("should return expected result", func() {
 				/* arrange */
-				predicateSpec := []*model.PredicateSpec{
-					&model.PredicateSpec{},
-				}
+				predicateSpec := []*model.PredicateSpec{{}}
 
 				/* act */
 				_, actualError := Interpret(
+					context.Background(),
 					map[string]*model.Value{},
 					&model.CallSpec{
 						If: &predicateSpec,
@@ -76,6 +76,7 @@ var _ = Context("Interpret", func() {
 
 			/* act */
 			actualCall, actualError := Interpret(
+				context.Background(),
 				providedScope,
 				&model.CallSpec{
 					Container: &containerSpec,
@@ -90,7 +91,6 @@ var _ = Context("Interpret", func() {
 			/* assert */
 			Expect(actualError).To(BeNil())
 			Expect(actualCall).To(Equal(expectedCall))
-
 		})
 	})
 	Context("callSpec.Op not nil", func() {
@@ -115,6 +115,7 @@ var _ = Context("Interpret", func() {
 			}
 
 			expectedOp, err := op.Interpret(
+				context.Background(),
 				providedScope,
 				&opSpec,
 				providedID,
@@ -134,6 +135,7 @@ var _ = Context("Interpret", func() {
 
 			/* act */
 			actualCall, actualError := Interpret(
+				context.Background(),
 				providedScope,
 				&model.CallSpec{
 					Op: &opSpec,
@@ -175,6 +177,7 @@ var _ = Context("Interpret", func() {
 
 			/* act */
 			actualCall, actualError := Interpret(
+				context.Background(),
 				providedScope,
 				&model.CallSpec{
 					Parallel: &parallelSpec,
@@ -214,6 +217,7 @@ var _ = Context("Interpret", func() {
 
 			/* act */
 			actualCall, actualError := Interpret(
+				context.Background(),
 				providedScope,
 				&model.CallSpec{
 					Serial: &serialSpec,

--- a/sdks/go/opspec/interpreter/call/op/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/interpret.go
@@ -19,6 +19,7 @@ import (
 
 // Interpret interprets an OpCallSpec into a OpCall
 func Interpret(
+	ctx context.Context,
 	scope map[string]*model.Value,
 	opCallSpec *model.OpCallSpec,
 	opID string,
@@ -60,7 +61,7 @@ func Interpret(
 		opPath = *dirValue.Dir
 	} else {
 		opHandle, err := data.Resolve(
-			context.TODO(),
+			ctx,
 			opCallSpec.Ref,
 			fs.New(parentOpPath, filepath.Dir(parentOpPath)),
 			git.New(filepath.Join(dataDirPath, "ops"), pkgPullCreds),
@@ -72,7 +73,7 @@ func Interpret(
 	}
 
 	opFile, err := opfile.Get(
-		context.TODO(),
+		ctx,
 		opPath,
 	)
 	if nil != err {


### PR DESCRIPTION
This sets a better pattern for cleanup after op completion or error and should overall help with reliability.

There are now only three places where we create a "root" context (background only, no TODOs)

1. When initializing the CLI
2. When killing containers. This can be triggered when the root context is cancelled, so we don't want to use that previously cancelled context.
3. When the API handler starts an op. This is an asynchronous API, and the op keeps running after the initial start request finishes.