### PR TITLE
Use unique temporary directory in tests instead of global one

### DIFF
--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
@@ -12,7 +12,9 @@ var _ = Context("CreateNodeIfNotExists", func() {
 	It("shouldn't panic", func() {
 		/* arrange */
 		dataDir, err := ioutil.TempDir("", "")
-		Expect(err).To(BeNil())
+		if err != nil {
+			panic(err)
+		}
 		nodeProvider := New(NodeCreateOpts{
 			DataDir: dataDir,
 		})

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
@@ -2,15 +2,19 @@ package local
 
 import (
 	"context"
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
-	"os"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Context("CreateNodeIfNotExists", func() {
 	It("shouldn't panic", func() {
 		/* arrange */
+		dataDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
 		nodeProvider := New(NodeCreateOpts{
-			DataDir: os.TempDir(),
+			DataDir: dataDir,
 		})
 
 		/* act */

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Context("CreateNodeIfNotExists", func() {

--- a/cli/internal/nodeprovider/local/killNodeIfExists_test.go
+++ b/cli/internal/nodeprovider/local/killNodeIfExists_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Context("KillNodeIfExists", func() {

--- a/cli/internal/nodeprovider/local/killNodeIfExists_test.go
+++ b/cli/internal/nodeprovider/local/killNodeIfExists_test.go
@@ -1,15 +1,19 @@
 package local
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
-	"os"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Context("KillNodeIfExists", func() {
 	It("shouldn't panic", func() {
 		/* arrange */
+		dataDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
 		nodeProvider := New(NodeCreateOpts{
-			DataDir: os.TempDir(),
+			DataDir: dataDir,
 		})
 
 		/* act */

--- a/cli/internal/nodeprovider/local/killNodeIfExists_test.go
+++ b/cli/internal/nodeprovider/local/killNodeIfExists_test.go
@@ -11,7 +11,9 @@ var _ = Context("KillNodeIfExists", func() {
 	It("shouldn't panic", func() {
 		/* arrange */
 		dataDir, err := ioutil.TempDir("", "")
-		Expect(err).To(BeNil())
+		if err != nil {
+			panic(err)
+		}
 		nodeProvider := New(NodeCreateOpts{
 			DataDir: dataDir,
 		})

--- a/cli/internal/nodeprovider/local/local_test.go
+++ b/cli/internal/nodeprovider/local/local_test.go
@@ -1,16 +1,19 @@
 package local
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
-	"os"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Context("New", func() {
 	It("shouldn't panic", func() {
 		/* arrange/act/assert */
+		dataDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
 		New(NodeCreateOpts{
-			DataDir: os.TempDir(),
+			DataDir: dataDir,
 		})
 	})
-
 })

--- a/cli/internal/nodeprovider/local/local_test.go
+++ b/cli/internal/nodeprovider/local/local_test.go
@@ -4,7 +4,6 @@ import (
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Context("New", func() {

--- a/cli/internal/nodeprovider/local/local_test.go
+++ b/cli/internal/nodeprovider/local/local_test.go
@@ -9,9 +9,13 @@ import (
 
 var _ = Context("New", func() {
 	It("shouldn't panic", func() {
-		/* arrange/act/assert */
+		/* arrange */
 		dataDir, err := ioutil.TempDir("", "")
-		Expect(err).To(BeNil())
+		if err != nil {
+			panic(err)
+		}
+
+		/* act */
 		New(NodeCreateOpts{
 			DataDir: dataDir,
 		})

--- a/sdks/go/data/coerce/toFile_test.go
+++ b/sdks/go/data/coerce/toFile_test.go
@@ -2,7 +2,7 @@ package coerce
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,7 +10,11 @@ import (
 )
 
 var _ = Context("ToFile", func() {
-	tmpDir := os.TempDir()
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		panic(err)
+	}
+
 	Context("Value is nil", func() {
 		Context("ioutil.WriteFile doesn't err", func() {
 			It("should return expected result", func() {

--- a/sdks/go/data/git/git_test.go
+++ b/sdks/go/data/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,7 +17,9 @@ var _ = Context("_git", func() {
 		Context("localFSProvider.TryResolve errors", func() {
 			It("should return err", func() {
 				/* arrange */
-				objectUnderTest := New(os.TempDir(), nil)
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
+				objectUnderTest := New(dataDir, nil)
 
 				/* act */
 				_, actualError := objectUnderTest.TryResolve(
@@ -53,7 +56,9 @@ var _ = Context("_git", func() {
 			Context("FSProvider.TryResolve doesn't return a handle", func() {
 				Context("puller.Pull errors", func() {
 					It("should return err", func() {
-						objectUnderTest := New(os.TempDir(), nil)
+						dataDir, err := ioutil.TempDir("", "")
+						Expect(err).To(BeNil())
+						objectUnderTest := New(dataDir, nil)
 
 						/* act */
 						_, actualErr := objectUnderTest.TryResolve(
@@ -71,7 +76,8 @@ var _ = Context("_git", func() {
 						// some public repo that's relatively small
 						providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
 
-						basePath := os.TempDir()
+						basePath, err := ioutil.TempDir("", "")
+						Expect(err).To(BeNil())
 						objectUnderTest := New(basePath, nil)
 
 						/* act */
@@ -93,7 +99,8 @@ var _ = Context("_git", func() {
 				// some public repo that's relatively small
 				providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
 
-				basePath := os.TempDir()
+				basePath, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
 				objectUnderTest := New(basePath, nil)
 
 				expectedResult := newHandle(filepath.Join(basePath, providedRef), providedRef)
@@ -143,7 +150,8 @@ var _ = Context("_git", func() {
 				providedRef1 := "github.com/opspec-pkgs/_.op.create#3.3.1"
 				providedRef2 := "github.com/opspec-pkgs/_.op.create#3.0.0"
 
-				basePath := os.TempDir()
+				basePath, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
 				objectUnderTest := New(basePath, nil)
 
 				expectedResult1 := newHandle(filepath.Join(basePath, providedRef1), providedRef1)

--- a/sdks/go/data/git/git_test.go
+++ b/sdks/go/data/git/git_test.go
@@ -18,7 +18,9 @@ var _ = Context("_git", func() {
 			It("should return err", func() {
 				/* arrange */
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 				objectUnderTest := New(dataDir, nil)
 
 				/* act */
@@ -57,7 +59,9 @@ var _ = Context("_git", func() {
 				Context("puller.Pull errors", func() {
 					It("should return err", func() {
 						dataDir, err := ioutil.TempDir("", "")
-						Expect(err).To(BeNil())
+						if err != nil {
+							panic(err)
+						}
 						objectUnderTest := New(dataDir, nil)
 
 						/* act */
@@ -75,9 +79,10 @@ var _ = Context("_git", func() {
 						/* arrange */
 						// some public repo that's relatively small
 						providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
-
 						basePath, err := ioutil.TempDir("", "")
-						Expect(err).To(BeNil())
+						if err != nil {
+							panic(err)
+						}
 						objectUnderTest := New(basePath, nil)
 
 						/* act */
@@ -100,7 +105,10 @@ var _ = Context("_git", func() {
 				providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
 
 				basePath, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
+
 				objectUnderTest := New(basePath, nil)
 
 				expectedResult := newHandle(filepath.Join(basePath, providedRef), providedRef)
@@ -151,7 +159,10 @@ var _ = Context("_git", func() {
 				providedRef2 := "github.com/opspec-pkgs/_.op.create#3.0.0"
 
 				basePath, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
+
 				objectUnderTest := New(basePath, nil)
 
 				expectedResult1 := newHandle(filepath.Join(basePath, providedRef1), providedRef1)

--- a/sdks/go/data/git/pull_test.go
+++ b/sdks/go/data/git/pull_test.go
@@ -33,7 +33,9 @@ var _ = Context("Pull", func() {
 
 					/* arrange */
 					providedPath, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 					// some small public repo
 					providedRef := "github.com/opspec-pkgs/_.op.create#3.2.0"
 
@@ -64,7 +66,9 @@ var _ = Context("Pull", func() {
 
 					/* arrange */
 					providedPath, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 
 					// some small private repo
 					providedRef := "github.com/Remitly/infra-ops#9.1.6"
@@ -88,7 +92,9 @@ var _ = Context("Pull", func() {
 
 					/* arrange */
 					providedPath, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 
 					// gitlab cuz github returns 404 not 403
 					providedRef := "gitlab.com/joetesterperson1/private#0.0.0"
@@ -115,7 +121,10 @@ var _ = Context("Pull", func() {
 
 					/* arrange */
 					providedPath, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
+
 					// non existent
 					providedRef := "dummyDataRef#0.0.0"
 

--- a/sdks/go/data/git/pull_test.go
+++ b/sdks/go/data/git/pull_test.go
@@ -3,7 +3,7 @@ package git
 import (
 	"context"
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,7 +32,8 @@ var _ = Context("Pull", func() {
 				It("shouldn't error", func() {
 
 					/* arrange */
-					providedPath := os.TempDir()
+					providedPath, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 					// some small public repo
 					providedRef := "github.com/opspec-pkgs/_.op.create#3.2.0"
 
@@ -62,7 +63,8 @@ var _ = Context("Pull", func() {
 				It("should return expected error", func() {
 
 					/* arrange */
-					providedPath := os.TempDir()
+					providedPath, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 
 					// some small private repo
 					providedRef := "github.com/Remitly/infra-ops#9.1.6"
@@ -85,7 +87,8 @@ var _ = Context("Pull", func() {
 				It("should return expected error", func() {
 
 					/* arrange */
-					providedPath := os.TempDir()
+					providedPath, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 
 					// gitlab cuz github returns 404 not 403
 					providedRef := "gitlab.com/joetesterperson1/private#0.0.0"
@@ -111,7 +114,8 @@ var _ = Context("Pull", func() {
 				It("should return error", func() {
 
 					/* arrange */
-					providedPath := os.TempDir()
+					providedPath, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 					// non existent
 					providedRef := "dummyDataRef#0.0.0"
 

--- a/sdks/go/node/core/caller_test.go
+++ b/sdks/go/node/core/caller_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -34,11 +35,13 @@ var _ = Context("caller", func() {
 			It("should not throw", func() {
 				/* arrange */
 				fakeContainerCaller := new(FakeContainerCaller)
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
 
 				/* act */
 				objectUnderTest := _caller{
 					containerCaller: fakeContainerCaller,
-					dataDirPath:     os.TempDir(),
+					dataDirPath:     dataDir,
 					pubSub:          new(FakePubSub),
 				}
 
@@ -92,9 +95,12 @@ var _ = Context("caller", func() {
 
 				fakeSerialCaller := new(FakeSerialCaller)
 
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
+
 				objectUnderTest := _caller{
 					containerCaller: new(FakeContainerCaller),
-					dataDirPath:     os.TempDir(),
+					dataDirPath:     dataDir,
 					pubSub:          fakePubSub,
 					serialCaller:    fakeSerialCaller,
 				}
@@ -163,9 +169,12 @@ var _ = Context("caller", func() {
 				// ensure eventChan closed so call exits
 				fakePubSub.SubscribeReturns(closedEventChan, nil)
 
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
+
 				objectUnderTest := _caller{
 					containerCaller: fakeContainerCaller,
-					dataDirPath:     os.TempDir(),
+					dataDirPath:     dataDir,
 					pubSub:          fakePubSub,
 				}
 
@@ -230,8 +239,11 @@ var _ = Context("caller", func() {
 				// ensure eventChan closed so call exits
 				fakePubSub.SubscribeReturns(closedEventChan, nil)
 
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
+
 				objectUnderTest := _caller{
-					dataDirPath: os.TempDir(),
+					dataDirPath: dataDir,
 					opCaller:    fakeOpCaller,
 					pubSub:      fakePubSub,
 				}

--- a/sdks/go/node/core/caller_test.go
+++ b/sdks/go/node/core/caller_test.go
@@ -36,7 +36,9 @@ var _ = Context("caller", func() {
 				/* arrange */
 				fakeContainerCaller := new(FakeContainerCaller)
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				/* act */
 				objectUnderTest := _caller{
@@ -96,7 +98,9 @@ var _ = Context("caller", func() {
 				fakeSerialCaller := new(FakeSerialCaller)
 
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				objectUnderTest := _caller{
 					containerCaller: new(FakeContainerCaller),
@@ -170,7 +174,9 @@ var _ = Context("caller", func() {
 				fakePubSub.SubscribeReturns(closedEventChan, nil)
 
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				objectUnderTest := _caller{
 					containerCaller: fakeContainerCaller,
@@ -240,7 +246,9 @@ var _ = Context("caller", func() {
 				fakePubSub.SubscribeReturns(closedEventChan, nil)
 
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				objectUnderTest := _caller{
 					dataDirPath: dataDir,

--- a/sdks/go/node/core/core_test.go
+++ b/sdks/go/node/core/core_test.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"context"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,11 +13,13 @@ var _ = Context("core", func() {
 	Context("New", func() {
 		It("should return Core", func() {
 			/* arrange/act/assert */
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 			Expect(
 				New(
 					context.Background(),
 					new(FakeContainerRuntime),
-					os.TempDir(),
+					dataDir,
 				),
 			).To(Not(BeNil()))
 		})

--- a/sdks/go/node/core/core_test.go
+++ b/sdks/go/node/core/core_test.go
@@ -12,9 +12,13 @@ import (
 var _ = Context("core", func() {
 	Context("New", func() {
 		It("should return Core", func() {
-			/* arrange/act/assert */
+			/* arrange */
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
+
+			/* act/assert */
 			Expect(
 				New(
 					context.Background(),

--- a/sdks/go/node/core/resolveData_test.go
+++ b/sdks/go/node/core/resolveData_test.go
@@ -14,7 +14,9 @@ var _ = Context("core", func() {
 		It("should call data.Resolve w/ expected args", func() {
 			/* arrange */
 			dataCachePath, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			providedCtx := context.Background()
 			// some public repo that's relatively small

--- a/sdks/go/node/core/resolveData_test.go
+++ b/sdks/go/node/core/resolveData_test.go
@@ -2,7 +2,7 @@ package core
 
 import (
 	"context"
-	"os"
+	"io/ioutil"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -13,7 +13,8 @@ var _ = Context("core", func() {
 	Context("ResolveData", func() {
 		It("should call data.Resolve w/ expected args", func() {
 			/* arrange */
-			dataCachePath := os.TempDir()
+			dataCachePath, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			providedCtx := context.Background()
 			// some public repo that's relatively small

--- a/sdks/go/node/core/startOp_test.go
+++ b/sdks/go/node/core/startOp_test.go
@@ -88,7 +88,9 @@ var _ = Context("core", func() {
 
 					fakeCaller := new(FakeCaller)
 					dataCachePath, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 
 					objectUnderTest := core{
 						caller:        fakeCaller,

--- a/sdks/go/node/core/startOp_test.go
+++ b/sdks/go/node/core/startOp_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -86,7 +87,8 @@ var _ = Context("core", func() {
 					}
 
 					fakeCaller := new(FakeCaller)
-					dataCachePath := os.TempDir()
+					dataCachePath, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 
 					objectUnderTest := core{
 						caller:        fakeCaller,

--- a/sdks/go/opspec/install_test.go
+++ b/sdks/go/opspec/install_test.go
@@ -59,7 +59,9 @@ var _ = Context("Install", func() {
 			)
 
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			// error to trigger immediate return
 			fakeHandle.GetContentReturns(nil, errors.New("dummyError"))

--- a/sdks/go/opspec/install_test.go
+++ b/sdks/go/opspec/install_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -59,11 +58,14 @@ var _ = Context("Install", func() {
 				nil,
 			)
 
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			// error to trigger immediate return
 			fakeHandle.GetContentReturns(nil, errors.New("dummyError"))
 
 			/* act */
-			Install(providedCtx, os.TempDir(), fakeHandle)
+			Install(providedCtx, dataDir, fakeHandle)
 
 			/* assert */
 			actualContext,

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
@@ -17,7 +17,9 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			identifier := "identifier"
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -98,7 +100,7 @@ var _ = Context("Interpret", func() {
 					/* act */
 					actualResult, actualErr := Interpret(
 						map[string]*model.Value{
-							identifier: &model.Value{Dir: &dirValue},
+							identifier: {Dir: &dirValue},
 						},
 						map[string]interface{}{
 							// implicitly bound

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -17,17 +16,20 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			identifier := "identifier"
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{
-					identifier: &model.Value{
+					identifier: {
 						Socket: new(string),
 					},
 				},
 				map[string]interface{}{
 					"/something": fmt.Sprintf("$(%s)", identifier),
 				},
-				os.TempDir(),
+				dataDir,
 				"dataDirPath",
 			)
 
@@ -41,25 +43,29 @@ var _ = Context("Interpret", func() {
 				/* arrange */
 				identifier := "identifier"
 
+				dataDir, err := ioutil.TempDir("", "")
+				if nil != err {
+					panic(err)
+				}
 				dirPath, err := ioutil.TempDir("", "")
 				if nil != err {
 					panic(err)
 				}
 
 				expectedDirs := map[string]string{
-					"/something": filepath.Join(os.TempDir(), "/something"),
+					"/something": filepath.Join(dataDir, "/something"),
 				}
 
 				/* act */
 				actualContainerCallDirs, actualErr := Interpret(
 					map[string]*model.Value{
-						identifier: &model.Value{Dir: &dirPath},
+						identifier: {Dir: &dirPath},
 					},
 					map[string]interface{}{
 						// implicitly bound
 						"/something": fmt.Sprintf("$(%s)", identifier),
 					},
-					os.TempDir(),
+					dataDir,
 					filepath.Dir(dirPath),
 				)
 

--- a/sdks/go/opspec/interpreter/call/container/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret_test.go
@@ -15,7 +15,9 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -43,7 +45,9 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			identifier := "identifier"
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -74,7 +78,9 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -99,7 +105,9 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -130,7 +138,9 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			dataDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -173,7 +183,9 @@ var _ = Context("Interpret", func() {
 		}
 
 		dataDir, err := ioutil.TempDir("", "")
-		Expect(err).To(BeNil())
+		if err != nil {
+			panic(err)
+		}
 
 		/* act */
 		actualResult, actualErr := Interpret(

--- a/sdks/go/opspec/interpreter/call/container/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret_test.go
@@ -3,7 +3,7 @@ package container
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,6 +14,9 @@ var _ = Context("Interpret", func() {
 	Context("cmd.Interpret errors", func() {
 		It("should return expected error", func() {
 			/* arrange */
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{},
@@ -27,7 +30,7 @@ var _ = Context("Interpret", func() {
 				},
 				"dummyContainerID",
 				"dummyOpPath",
-				os.TempDir(),
+				dataDir,
 			)
 
 			/* assert */
@@ -39,6 +42,8 @@ var _ = Context("Interpret", func() {
 		It("should return expected error", func() {
 			/* arrange */
 			identifier := "identifier"
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			/* act */
 			_, actualErr := Interpret(
@@ -57,7 +62,7 @@ var _ = Context("Interpret", func() {
 				},
 				"dummyContainerID",
 				"dummyOpPath",
-				os.TempDir(),
+				dataDir,
 			)
 
 			/* assert */
@@ -68,6 +73,9 @@ var _ = Context("Interpret", func() {
 	Context("envVars.Interpret errors", func() {
 		It("should return expected error", func() {
 			/* arrange */
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{},
@@ -79,7 +87,7 @@ var _ = Context("Interpret", func() {
 				},
 				"dummyContainerID",
 				"dummyOpPath",
-				os.TempDir(),
+				dataDir,
 			)
 
 			/* assert */
@@ -90,6 +98,9 @@ var _ = Context("Interpret", func() {
 	Context("files.Interpret errors", func() {
 		It("should return expected error", func() {
 			/* arrange */
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{
@@ -107,7 +118,7 @@ var _ = Context("Interpret", func() {
 				},
 				"dummyContainerID",
 				"dummyOpPath",
-				os.TempDir(),
+				dataDir,
 			)
 
 			/* assert */
@@ -118,6 +129,9 @@ var _ = Context("Interpret", func() {
 	Context("image.Interpret errors", func() {
 		It("should return expected error", func() {
 			/* arrange */
+			dataDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{},
@@ -128,7 +142,7 @@ var _ = Context("Interpret", func() {
 				},
 				"dummyContainerID",
 				"dummyOpPath",
-				os.TempDir(),
+				dataDir,
 			)
 
 			/* assert */
@@ -158,6 +172,9 @@ var _ = Context("Interpret", func() {
 			WorkDir: "",
 		}
 
+		dataDir, err := ioutil.TempDir("", "")
+		Expect(err).To(BeNil())
+
 		/* act */
 		actualResult, actualErr := Interpret(
 			map[string]*model.Value{},
@@ -168,7 +185,7 @@ var _ = Context("Interpret", func() {
 			},
 			providedContainerID,
 			providedOpPath,
-			os.TempDir(),
+			dataDir,
 		)
 
 		/* assert */

--- a/sdks/go/opspec/interpreter/call/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/interpret_test.go
@@ -21,7 +21,9 @@ var _ = Context("Interpret", func() {
 				/* arrange */
 				predicateSpec := []*model.PredicateSpec{{}}
 				dataDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				/* act */
 				_, actualError := Interpret(
@@ -52,7 +54,9 @@ var _ = Context("Interpret", func() {
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
 			providedDataDirPath, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			containerSpec := model.ContainerCallSpec{
 				Image: &model.ContainerCallImageSpec{
@@ -107,7 +111,9 @@ var _ = Context("Interpret", func() {
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
 			providedDataDirPath, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			wd, err := os.Getwd()
 			if nil != err {
@@ -170,7 +176,9 @@ var _ = Context("Interpret", func() {
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
 			providedDataDirPath, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			parallelSpec := []*model.CallSpec{}
 
@@ -211,7 +219,9 @@ var _ = Context("Interpret", func() {
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
 			providedDataDirPath, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			serialSpec := []*model.CallSpec{}
 

--- a/sdks/go/opspec/interpreter/call/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/interpret_test.go
@@ -3,6 +3,7 @@ package call
 import (
 	"context"
 	"errors"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -19,6 +20,8 @@ var _ = Context("Interpret", func() {
 			It("should return expected result", func() {
 				/* arrange */
 				predicateSpec := []*model.PredicateSpec{{}}
+				dataDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
 
 				/* act */
 				_, actualError := Interpret(
@@ -31,7 +34,7 @@ var _ = Context("Interpret", func() {
 					"dummyOpPath",
 					nil,
 					"providedRootCallID",
-					os.TempDir(),
+					dataDir,
 				)
 
 				/* assert */
@@ -48,7 +51,8 @@ var _ = Context("Interpret", func() {
 			providedParentIDValue := "providedParentID"
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
-			providedDataDirPath := os.TempDir()
+			providedDataDirPath, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			containerSpec := model.ContainerCallSpec{
 				Image: &model.ContainerCallImageSpec{
@@ -102,7 +106,8 @@ var _ = Context("Interpret", func() {
 			providedParentIDValue := "providedParentID"
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
-			providedDataDirPath := os.TempDir()
+			providedDataDirPath, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			wd, err := os.Getwd()
 			if nil != err {
@@ -164,7 +169,8 @@ var _ = Context("Interpret", func() {
 			providedParentIDValue := "providedParentID"
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
-			providedDataDirPath := os.TempDir()
+			providedDataDirPath, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			parallelSpec := []*model.CallSpec{}
 
@@ -204,7 +210,8 @@ var _ = Context("Interpret", func() {
 			providedParentIDValue := "providedParentID"
 			providedParentID := &providedParentIDValue
 			providedRootCallID := "providedRootCallID"
-			providedDataDirPath := os.TempDir()
+			providedDataDirPath, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			serialSpec := []*model.CallSpec{}
 

--- a/sdks/go/opspec/interpreter/dir/interpret_test.go
+++ b/sdks/go/opspec/interpreter/dir/interpret_test.go
@@ -17,7 +17,9 @@ var _ = Context("Interpret", func() {
 				/* arrange */
 				identifier := "identifier"
 				scratchDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				/* act */
 				_, actualErr := Interpret(
@@ -46,7 +48,9 @@ var _ = Context("Interpret", func() {
 					}
 					providedExpression := fmt.Sprintf("$(%s)", identifier)
 					scratchDir, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 
 					/* act */
 					_, actualErr := Interpret(
@@ -68,7 +72,9 @@ var _ = Context("Interpret", func() {
 						identifier: {Dir: new(string)},
 					}
 					scratchDir, err := ioutil.TempDir("", "")
-					Expect(err).To(BeNil())
+					if err != nil {
+						panic(err)
+					}
 
 					/* act */
 					actualResult, actualErr := Interpret(

--- a/sdks/go/opspec/interpreter/dir/interpret_test.go
+++ b/sdks/go/opspec/interpreter/dir/interpret_test.go
@@ -3,7 +3,7 @@ package dir
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,15 +16,18 @@ var _ = Context("Interpret", func() {
 			It("should return expected result", func() {
 				/* arrange */
 				identifier := "identifier"
+				scratchDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
+
 				/* act */
 				_, actualErr := Interpret(
 					map[string]*model.Value{
-						identifier: &model.Value{
+						identifier: {
 							Socket: new(string),
 						},
 					},
 					fmt.Sprintf("$(%s)", identifier),
-					os.TempDir(),
+					scratchDir,
 					true,
 				)
 
@@ -39,15 +42,17 @@ var _ = Context("Interpret", func() {
 					/* arrange */
 					identifier := "identifier"
 					providedScope := map[string]*model.Value{
-						identifier: &model.Value{Dir: nil},
+						identifier: {Dir: nil},
 					}
 					providedExpression := fmt.Sprintf("$(%s)", identifier)
+					scratchDir, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 
 					/* act */
 					_, actualErr := Interpret(
 						providedScope,
 						providedExpression,
-						os.TempDir(),
+						scratchDir,
 						true,
 					)
 
@@ -60,14 +65,16 @@ var _ = Context("Interpret", func() {
 					/* arrange */
 					identifier := "identifier"
 					providedScope := map[string]*model.Value{
-						identifier: &model.Value{Dir: new(string)},
+						identifier: {Dir: new(string)},
 					}
+					scratchDir, err := ioutil.TempDir("", "")
+					Expect(err).To(BeNil())
 
 					/* act */
 					actualResult, actualErr := Interpret(
 						providedScope,
 						fmt.Sprintf("$(%s)", identifier),
-						os.TempDir(),
+						scratchDir,
 						true,
 					)
 

--- a/sdks/go/opspec/interpreter/file/interpret_test.go
+++ b/sdks/go/opspec/interpreter/file/interpret_test.go
@@ -34,7 +34,9 @@ var _ = Context("Interpret", func() {
 				identifier := "identifier"
 				expectedValue := model.Value{File: new(string)}
 				scratchDir, err := ioutil.TempDir("", "")
-				Expect(err).To(BeNil())
+				if err != nil {
+					panic(err)
+				}
 
 				/* act */
 				actualResultValue, actualErr := Interpret(
@@ -56,7 +58,9 @@ var _ = Context("Interpret", func() {
 		It("should return expected result", func() {
 			/* arrange */
 			scratchDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			_, actualErr := Interpret(
@@ -75,7 +79,9 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedExpression := model.Value{File: new(string)}
 			scratchDir, err := ioutil.TempDir("", "")
-			Expect(err).To(BeNil())
+			if err != nil {
+				panic(err)
+			}
 
 			/* act */
 			actualResultValue, actualErr := Interpret(

--- a/sdks/go/opspec/interpreter/file/interpret_test.go
+++ b/sdks/go/opspec/interpreter/file/interpret_test.go
@@ -3,7 +3,7 @@ package file
 import (
 	"errors"
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,8 +32,9 @@ var _ = Context("Interpret", func() {
 			It("should return expected result", func() {
 				/* arrange */
 				identifier := "identifier"
-
 				expectedValue := model.Value{File: new(string)}
+				scratchDir, err := ioutil.TempDir("", "")
+				Expect(err).To(BeNil())
 
 				/* act */
 				actualResultValue, actualErr := Interpret(
@@ -41,7 +42,7 @@ var _ = Context("Interpret", func() {
 						identifier: &expectedValue,
 					},
 					fmt.Sprintf("$(%s)", identifier),
-					os.TempDir(),
+					scratchDir,
 					false,
 				)
 
@@ -54,11 +55,14 @@ var _ = Context("Interpret", func() {
 	Context("value.Interpret errs", func() {
 		It("should return expected result", func() {
 			/* arrange */
+			scratchDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
+
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{},
 				nil,
-				os.TempDir(),
+				scratchDir,
 				false,
 			)
 
@@ -70,12 +74,14 @@ var _ = Context("Interpret", func() {
 		It("should return expected result", func() {
 			/* arrange */
 			providedExpression := model.Value{File: new(string)}
+			scratchDir, err := ioutil.TempDir("", "")
+			Expect(err).To(BeNil())
 
 			/* act */
 			actualResultValue, actualErr := Interpret(
 				map[string]*model.Value{},
 				providedExpression,
-				os.TempDir(),
+				scratchDir,
 				false,
 			)
 


### PR DESCRIPTION
This makes one-off testing more reliable during local development. I've run into a few cases where running local tests, e.g. through vscode's debugger, fails due to leftover files from prior test runs.