### PR TITLE
Error wrapping cleanup

### DIFF
--- a/cli/internal/cliparamsatisfier/cliParamSatisfier.go
+++ b/cli/internal/cliparamsatisfier/cliParamSatisfier.go
@@ -61,7 +61,7 @@ func (cps _CLIParamSatisfier) Satisfy(
 			if !ok {
 				return nil, fmt.Errorf(`
 -
-  Prompt for "%v" failed; running in non-interactive terminal
+  Prompt for '%v' failed; running in non-interactive terminal
 -`, paramName)
 			}
 

--- a/cli/internal/cliparamsatisfier/cliParamSatisfier_test.go
+++ b/cli/internal/cliparamsatisfier/cliParamSatisfier_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
+
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,7 +14,6 @@ import (
 	"github.com/opctl/opctl/cli/internal/clioutput"
 	. "github.com/opctl/opctl/cli/internal/cliparamsatisfier/internal/fakes"
 	"github.com/opctl/opctl/sdks/go/model"
-	"path/filepath"
 )
 
 var _ = Context("parameterSatisfier", func() {
@@ -113,11 +115,11 @@ var _ = Context("parameterSatisfier", func() {
 					}
 
 					valueBool := true
-					valueString := fmt.Sprintf("%v", valueBool)
+					valueString := strconv.FormatBool(valueBool)
 					providedInputSourcer.SourceReturns(&valueString, true)
 
 					expectedOutputs := map[string]*model.Value{
-						inputIdentifier: &model.Value{Boolean: &valueBool},
+						inputIdentifier: {Boolean: &valueBool},
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
@@ -153,7 +155,7 @@ var _ = Context("parameterSatisfier", func() {
 					providedInputSourcer.SourceReturns(&valueDir, true)
 
 					expectedOutputs := map[string]*model.Value{
-						inputIdentifier: &model.Value{Dir: &valueDir},
+						inputIdentifier: {Dir: &valueDir},
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
@@ -221,7 +223,7 @@ var _ = Context("parameterSatisfier", func() {
 					providedInputSourcer.SourceReturns(&valueString, true)
 
 					expectedOutputs := map[string]*model.Value{
-						inputIdentifier: &model.Value{Number: &valueNumber},
+						inputIdentifier: {Number: &valueNumber},
 					}
 
 					objectUnderTest := _CLIParamSatisfier{

--- a/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt.go
+++ b/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt.go
@@ -64,7 +64,7 @@ func (this cliPromptInputSrc) ReadString(
 		this.cliOutput.Attention(
 			fmt.Sprintf(`
 -
-  Please provide "%v".
+  Please provide '%v'.
   Description: %v
 -`,
 				inputName,

--- a/cli/internal/datadir/datadir.go
+++ b/cli/internal/datadir/datadir.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 
 	"github.com/golang-utils/lockfile"
+	"github.com/pkg/errors"
 )
 
 // DataDir is an interface exposing the functionality we require in conjunction with our "data dir".
@@ -35,11 +36,11 @@ func New(
 ) (DataDir, error) {
 	resolvedDataDirPath, err := filepath.Abs(dataDirPath)
 	if nil != err {
-		return nil, fmt.Errorf("error initializing opctl data dir; error was %v", err)
+		return nil, errors.Wrap(err, "error initializing opctl data dir")
 	}
 
 	if err := ensureExists(resolvedDataDirPath); nil != err {
-		return nil, fmt.Errorf("error initializing opctl data dir; error was %v", err)
+		return nil, errors.Wrap(err, "error initializing opctl data dir")
 	}
 
 	// ensure we can write
@@ -48,7 +49,7 @@ func New(
 		[]byte(""),
 		0775,
 	); nil != err {
-		return nil, fmt.Errorf("error initializing opctl data dir; error was %v", err)
+		return nil, errors.Wrap(err, "error initializing opctl data dir")
 	}
 
 	return _datadir{
@@ -78,7 +79,7 @@ func (dd _datadir) InitAndLock() error {
 	lockFile := lockfile.New()
 	if err := lockFile.Lock(lockFilePath); nil != err {
 		pIDOfExistingNode := lockFile.PIdOfOwner(lockFilePath)
-		return fmt.Errorf("node already running w/ PId: %v", pIDOfExistingNode)
+		return fmt.Errorf("node already running with PID: %d", pIDOfExistingNode)
 	}
 
 	return nil

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_unix.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_unix.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/opctl/opctl/sdks/go/node"
+	"github.com/pkg/errors"
 )
 
 func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, error) {
@@ -76,7 +77,7 @@ func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, er
 	nodeLogBytes, _ := ioutil.ReadFile(nodeLogFilePath)
 	fmt.Println(string(nodeLogBytes))
 	if nil != err {
-		return nil, fmt.Errorf("Error encountered creating daemonized opctl node; error was %s", err)
+		return nil, errors.Wrap(err, "failed to create daemonized opctl node")
 	}
 
 	return apiClientNode, nil

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_windows.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_windows.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/opctl/opctl/sdks/go/node"
+	"github.com/pkg/errors"
 )
 
 func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, error) {
@@ -74,7 +75,7 @@ func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, er
 	nodeLogBytes, _ := ioutil.ReadFile(nodeLogFilePath)
 	fmt.Println(string(nodeLogBytes))
 	if nil != err {
-		return nil, fmt.Errorf("Error encountered creating daemonized opctl node; error was %s", err)
+		return nil, errors.Wrap(err, "failed to create daemonized opctl node")
 	}
 
 	return apiClientNode, nil

--- a/cli/run.go
+++ b/cli/run.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"github.com/opctl/opctl/cli/internal/nodeprovider"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
+	"github.com/pkg/errors"
 )
 
 // run implements "run" command
@@ -72,7 +72,7 @@ func run(
 
 	ymlFileInputSrc, err := cliParamSatisfier.NewYMLFileInputSrc(argFile)
 	if nil != err {
-		return fmt.Errorf("unable to load arg file at '%v'; error was: %v", argFile, err.Error())
+		return errors.Wrap(err, fmt.Sprintf("unable to load arg file at '%v'", argFile))
 	}
 
 	argsMap, err := cliParamSatisfier.Satisfy(

--- a/cli/selfUpdate.go
+++ b/cli/selfUpdate.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/blang/semver"
 	"github.com/opctl/opctl/cli/internal/nodeprovider"
+	"github.com/pkg/errors"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 )
 
@@ -24,7 +26,7 @@ func selfUpdate(
 	// @TODO start node maintaining previous user
 	err = nodeProvider.KillNodeIfExists("")
 	if nil != err {
-		err = fmt.Errorf("Unable to kill running node; run `node kill` to complete the update. Error was: %v", err)
+		err = errors.Wrap(err, "unable to kill running node; run `node kill` to complete the update")
 	}
 	return fmt.Sprintf("Updated to new version: %s!", latest.Version), err
 }

--- a/examples/run-a-go-service/vendor/github.com/go-sql-driver/mysql/dsn.go
+++ b/examples/run-a-go-service/vendor/github.com/go-sql-driver/mysql/dsn.go
@@ -12,14 +12,14 @@ import (
 	"bytes"
 	"crypto/rsa"
 	"crypto/tls"
-	"errors"
-	"fmt"
 	"net"
 	"net/url"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -529,7 +529,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 		case "serverPubKey":
 			name, err := url.QueryUnescape(value)
 			if err != nil {
-				return fmt.Errorf("invalid value for server pub key name: %v", err)
+				return errors.Wrap(err, "invalid value for server pub key name")
 			}
 
 			if pubKey := getServerPubKey(name); pubKey != nil {
@@ -566,7 +566,7 @@ func parseDSNParams(cfg *Config, params string) (err error) {
 			} else {
 				name, err := url.QueryUnescape(value)
 				if err != nil {
-					return fmt.Errorf("invalid value for TLS config name: %v", err)
+					return errors.Wrap(err, "invalid value for TLS config name")
 				}
 
 				if tlsConfig := getTLSConfigClone(name); tlsConfig != nil {

--- a/sdks/go/data/coerce/errors.go
+++ b/sdks/go/data/coerce/errors.go
@@ -1,0 +1,7 @@
+package coerce
+
+import (
+	"github.com/pkg/errors"
+)
+
+var errIncompatibleTypes = errors.New("incompatible types")

--- a/sdks/go/data/coerce/toArray.go
+++ b/sdks/go/data/coerce/toArray.go
@@ -3,8 +3,10 @@ package coerce
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opctl/opctl/sdks/go/model"
 	"io/ioutil"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToArray coerces a value to an array value
@@ -13,33 +15,33 @@ func ToArray(
 ) (*model.Value, error) {
 	switch {
 	case nil == value:
-		return nil, fmt.Errorf("unable to coerce null to array")
+		return nil, errors.New("unable to coerce null to array")
 	case nil != value.Array:
 		return value, nil
 	case nil != value.Boolean:
-		return nil, fmt.Errorf("unable to coerce boolean to array; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce boolean to array")
 	case nil != value.Dir:
-		return nil, fmt.Errorf("unable to coerce dir to array; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to array")
 	case nil != value.File:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to array; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to array")
 		}
 		valueArray := new([]interface{})
 		err = json.Unmarshal([]byte(fileBytes), valueArray)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to array; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to array")
 		}
 		return &model.Value{Array: valueArray}, nil
 	case nil != value.Number:
-		return nil, fmt.Errorf("unable to coerce number to array; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce number to array")
 	case nil != value.Socket:
-		return nil, fmt.Errorf("unable to coerce socket to array; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce socket to array")
 	case nil != value.String:
 		valueArray := new([]interface{})
 		err := json.Unmarshal([]byte(*value.String), valueArray)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce string to array; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce string to array")
 		}
 		return &model.Value{Array: valueArray}, nil
 	default:

--- a/sdks/go/data/coerce/toArray_test.go
+++ b/sdks/go/data/coerce/toArray_test.go
@@ -1,7 +1,6 @@
 package coerce
 
 import (
-	"errors"
 	"fmt"
 
 	"io/ioutil"
@@ -21,7 +20,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce null to array")))
+			Expect(actualErr).To(MatchError("unable to coerce null to array"))
 		})
 	})
 	Context("Value.Array isn't nil", func() {
@@ -53,7 +52,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce boolean to array; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce boolean to array: incompatible types"))
 		})
 	})
 	Context("Value.Dir isn't nil", func() {
@@ -69,7 +68,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce dir to array; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce dir to array: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {
@@ -85,7 +84,7 @@ var _ = Context("ToArray", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce file to array; error was open nonExistent: no such file or directory")))
+				Expect(actualErr).To(MatchError("unable to coerce file to array: open nonExistent: no such file or directory"))
 			})
 		})
 		Context("ioutil.ReadFile doesn't err", func() {
@@ -107,7 +106,7 @@ var _ = Context("ToArray", func() {
 
 					/* assert */
 					Expect(actualValue).To(BeNil())
-					Expect(actualErr).To(Equal(errors.New("unable to coerce file to array; error was unexpected end of JSON input")))
+					Expect(actualErr).To(MatchError("unable to coerce file to array: unexpected end of JSON input"))
 				})
 			})
 			Context("json.Unmarshal doesn't err", func() {
@@ -155,7 +154,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce number to array; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce number to array: incompatible types"))
 		})
 	})
 	Context("Value.Socket isn't nil", func() {
@@ -171,7 +170,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce socket to array; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce socket to array: incompatible types"))
 		})
 	})
 	Context("Value.String isn't nil", func() {
@@ -186,7 +185,7 @@ var _ = Context("ToArray", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce string to array; error was unexpected end of JSON input")))
+				Expect(actualErr).To(MatchError("unable to coerce string to array: unexpected end of JSON input"))
 			})
 		})
 		Context("json.Unmarshal doesn't err", func() {
@@ -219,7 +218,7 @@ var _ = Context("ToArray", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to array", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to array"))
 		})
 	})
 })

--- a/sdks/go/data/coerce/toBoolean.go
+++ b/sdks/go/data/coerce/toBoolean.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // isStringTruthy ensures value isn't:
@@ -36,11 +37,11 @@ func ToBoolean(
 	case nil != value.Boolean:
 		return value, nil
 	case nil != value.Dir:
-		return nil, fmt.Errorf("unable to coerce dir to boolean; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to boolean")
 	case nil != value.File:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to boolean; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to boolean")
 		}
 
 		booleanValue := isStringTruthy(string(fileBytes))

--- a/sdks/go/data/coerce/toBoolean_test.go
+++ b/sdks/go/data/coerce/toBoolean_test.go
@@ -1,8 +1,6 @@
 package coerce
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
@@ -89,7 +87,7 @@ var _ = Context("ToBoolean", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce dir to boolean; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce dir to boolean: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {
@@ -103,7 +101,7 @@ var _ = Context("ToBoolean", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce file to boolean; error was open : no such file or directory")))
+				Expect(actualErr).To(MatchError("unable to coerce file to boolean: open : no such file or directory"))
 			})
 		})
 		Context("ioutil.ReadFile doesn't err", func() {
@@ -249,7 +247,7 @@ var _ = Context("ToBoolean", func() {
 
 			/* assert */
 			Expect(actualBoolean).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to boolean", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to boolean"))
 		})
 	})
 })

--- a/sdks/go/data/coerce/toDir.go
+++ b/sdks/go/data/coerce/toDir.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToDir attempts to coerce value to a dir
@@ -18,34 +19,34 @@ func ToDir(
 ) (*model.Value, error) {
 	switch {
 	case nil == value:
-		return nil, fmt.Errorf("unable to coerce null to dir")
+		return nil, errors.New("unable to coerce null to dir")
 	case nil != value.Array:
-		return nil, fmt.Errorf("unable to coerce array to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to dir")
 	case nil != value.Boolean:
-		return nil, fmt.Errorf("unable to coerce boolean to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce boolean to dir")
 	case nil != value.Dir:
 		return value, nil
 	case nil != value.File:
-		return nil, fmt.Errorf("unable to coerce file to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce file to dir")
 	case nil != value.Number:
-		return nil, fmt.Errorf("unable to coerce number to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce number to dir")
 	case nil != value.Object:
 		uniqueStr, err := uniquestring.Construct()
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to dir; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce object to dir")
 		}
 
 		rootDirPath := filepath.Join(scratchDir, uniqueStr)
 		err = rCreateFileItem(rootDirPath, "", *value.Object)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to dir; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce object to dir")
 		}
 
 		return &model.Value{Dir: &rootDirPath}, nil
 	case nil != value.Socket:
-		return nil, fmt.Errorf("unable to coerce socket to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce socket to dir")
 	case nil != value.String:
-		return nil, fmt.Errorf("unable to coerce string to dir; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce string to dir")
 	default:
 		return nil, fmt.Errorf("unable to coerce '%+v' to dir", value)
 	}
@@ -72,12 +73,12 @@ func rCreateFileItem(
 			0777,
 		)
 		if nil != err {
-			return fmt.Errorf("error creating %s; error was %s", itemPath, err.Error())
+			return errors.Wrap(err, "error creating "+itemPath)
 		}
 
 		err = ioutil.WriteFile(itemPath, []byte(dataString), 0777)
 		if nil != err {
-			return fmt.Errorf("error creating %s; error was %s", itemPath, err.Error())
+			return errors.Wrap(err, "error creating "+itemPath)
 		}
 
 		return nil
@@ -89,12 +90,12 @@ func rCreateFileItem(
 		0777,
 	)
 	if nil != err {
-		return fmt.Errorf("error creating %s; error was %s", itemPath, err.Error())
+		return errors.Wrap(err, "error creating "+itemPath)
 	}
 
 	for k, v := range children {
 		if !strings.HasPrefix(k, "") {
-			return fmt.Errorf("%s %s must start with '/'", relParentPath, k)
+			return fmt.Errorf(`%s %s must start with "/"`, relParentPath, k)
 		}
 
 		relChildPath := filepath.Join(relParentPath, k)

--- a/sdks/go/data/coerce/toDir_test.go
+++ b/sdks/go/data/coerce/toDir_test.go
@@ -1,8 +1,6 @@
 package coerce
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"strings"
 
@@ -21,7 +19,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce null to dir")))
+			Expect(actualErr).To(MatchError("unable to coerce null to dir"))
 		})
 	})
 	Context("Value.Array isn't nil", func() {
@@ -37,7 +35,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce array to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce array to dir: incompatible types"))
 		})
 	})
 	Context("Value.Boolean isn't nil", func() {
@@ -53,7 +51,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce boolean to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce boolean to dir: incompatible types"))
 		})
 	})
 	Context("Value.Dir isn't nil", func() {
@@ -83,7 +81,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce file to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce file to dir: incompatible types"))
 		})
 	})
 	Context("Value.Number isn't nil", func() {
@@ -99,7 +97,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce number to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce number to dir: incompatible types"))
 		})
 	})
 	Context("Value.Object isn't nil", func() {
@@ -173,7 +171,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce socket to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce socket to dir: incompatible types"))
 		})
 	})
 	Context("Value.String isn't nil", func() {
@@ -188,7 +186,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce string to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce string to dir: incompatible types"))
 		})
 	})
 	Context("Value.Array,Dir,File,Number,Dir,Socket,String nil", func() {
@@ -201,7 +199,7 @@ var _ = Context("ToDir", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to dir", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to dir"))
 		})
 	})
 })

--- a/sdks/go/data/coerce/toFile.go
+++ b/sdks/go/data/coerce/toFile.go
@@ -3,12 +3,14 @@ package coerce
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
-	"github.com/opctl/opctl/sdks/go/model"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToFile attempts to coerce value to a file
@@ -24,17 +26,17 @@ func ToFile(
 	case nil != value.Array:
 		nativeArray, err := value.Unbox()
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce array to file; error was %v", err)
+			return nil, errors.Wrap(err, "unable to coerce array to file")
 		}
 
 		data, err = json.Marshal(nativeArray)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce array to file; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce array to file")
 		}
 	case nil != value.Boolean:
 		data = []byte(strconv.FormatBool(*value.Boolean))
 	case nil != value.Dir:
-		return nil, fmt.Errorf("unable to coerce dir '%v' to file; incompatible types", *value.Dir)
+		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to file", *value.Dir))
 	case nil != value.File:
 		return value, nil
 	case nil != value.Number:
@@ -42,12 +44,12 @@ func ToFile(
 	case nil != value.Object:
 		nativeObject, err := value.Unbox()
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to file; error was %v", err)
+			return nil, errors.Wrap(err, "unable to coerce object to file")
 		}
 
 		data, err = json.Marshal(nativeObject)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to file; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce object to file")
 		}
 	case nil != value.String:
 		data = []byte(*value.String)
@@ -58,7 +60,7 @@ func ToFile(
 
 	uniqueStr, err := uniquestring.Construct()
 	if nil != err {
-		return nil, fmt.Errorf("unable to coerce '%+v' to file; error was %v", value, err.Error())
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to coerce '%+v' to file", value))
 	}
 
 	path := filepath.Join(scratchDir, uniqueStr)
@@ -80,7 +82,7 @@ func ToFile(
 	}
 
 	if nil != err {
-		return nil, fmt.Errorf("unable to coerce '%#v' to file; error was %v", value, err.Error())
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to coerce '%+v' to file", value))
 	}
 
 	return &model.Value{File: &path}, nil

--- a/sdks/go/data/coerce/toFile_test.go
+++ b/sdks/go/data/coerce/toFile_test.go
@@ -1,7 +1,6 @@
 package coerce
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
@@ -90,7 +89,7 @@ var _ = Context("ToFile", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce dir '%v' to file; incompatible types", providedDir)))
+			Expect(actualErr).To(MatchError("unable to coerce dir 'dummyValue' to file: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {

--- a/sdks/go/data/coerce/toNumber.go
+++ b/sdks/go/data/coerce/toNumber.go
@@ -1,11 +1,12 @@
 package coerce
 
 import (
-	"errors"
 	"fmt"
-	"github.com/opctl/opctl/sdks/go/model"
 	"io/ioutil"
 	"strconv"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToNumber coerces a value to a number value
@@ -16,28 +17,28 @@ func ToNumber(
 	case nil == value:
 		return &model.Value{Number: new(float64)}, nil
 	case nil != value.Array:
-		return nil, errors.New("unable to coerce array to number; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to number")
 	case nil != value.Dir:
-		return nil, errors.New("unable to coerce dir to number; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to number")
 	case nil != value.File:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to number; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to number")
 		}
 
 		float64Value, err := strconv.ParseFloat(string(fileBytes), 64)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to number; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to number")
 		}
 		return &model.Value{Number: &float64Value}, nil
 	case nil != value.Number:
 		return value, nil
 	case nil != value.Object:
-		return nil, errors.New("unable to coerce object to number; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce object to number")
 	case nil != value.String:
 		float64Value, err := strconv.ParseFloat(*value.String, 64)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce string to number; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce string to number")
 		}
 		return &model.Value{Number: &float64Value}, nil
 	default:

--- a/sdks/go/data/coerce/toNumber_test.go
+++ b/sdks/go/data/coerce/toNumber_test.go
@@ -1,7 +1,6 @@
 package coerce
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"strconv"
@@ -35,7 +34,7 @@ var _ = Context("ToNumber", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce array to number; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce array to number: incompatible types"))
 		})
 	})
 	Context("Value.Dir isn't nil", func() {
@@ -51,7 +50,7 @@ var _ = Context("ToNumber", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce dir to number; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce dir to number: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {
@@ -65,7 +64,7 @@ var _ = Context("ToNumber", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce file to number; error was open : no such file or directory")))
+				Expect(actualErr).To(MatchError("unable to coerce file to number: open : no such file or directory"))
 			})
 		})
 		Context("ioutil.ReadFile doesn't err", func() {
@@ -122,7 +121,7 @@ var _ = Context("ToNumber", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(errors.New("unable to coerce object to number; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce object to number: incompatible types"))
 		})
 	})
 	Context("Value.String isn't nil", func() {
@@ -156,7 +155,7 @@ var _ = Context("ToNumber", func() {
 
 			/* assert */
 			Expect(actualNumber).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to number", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to number"))
 		})
 	})
 })

--- a/sdks/go/data/coerce/toObject.go
+++ b/sdks/go/data/coerce/toObject.go
@@ -3,8 +3,10 @@ package coerce
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opctl/opctl/sdks/go/model"
 	"io/ioutil"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToObject coerces a value to an object value
@@ -15,29 +17,29 @@ func ToObject(
 	case nil == value:
 		return nil, nil
 	case nil != value.Array:
-		return nil, fmt.Errorf("unable to coerce array to object; incompatible types")
+		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to object")
 	case nil != value.Dir:
-		return nil, fmt.Errorf("unable to coerce dir '%v' to object; incompatible types", *value.Dir)
+		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to object", *value.Dir))
 	case nil != value.File:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to object; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to object")
 		}
 		valueMap := &map[string]interface{}{}
 		err = json.Unmarshal([]byte(fileBytes), valueMap)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to object; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to object")
 		}
 		return &model.Value{Object: valueMap}, nil
 	case nil != value.Number:
-		return nil, fmt.Errorf("unable to coerce number '%v' to object; incompatible types", *value.Number)
+		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce number '%v' to object", *value.Number))
 	case nil != value.Object:
 		return value, nil
 	case nil != value.String:
 		valueMap := &map[string]interface{}{}
 		err := json.Unmarshal([]byte(*value.String), valueMap)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce string to object; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce string to object")
 		}
 		return &model.Value{Object: valueMap}, nil
 	default:

--- a/sdks/go/data/coerce/toObject_test.go
+++ b/sdks/go/data/coerce/toObject_test.go
@@ -1,7 +1,6 @@
 package coerce
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -34,7 +33,7 @@ var _ = Context("ToObject", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce array to object; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to coerce array to object: incompatible types"))
 		})
 	})
 	Context("Value.Dir isn't nil", func() {
@@ -50,7 +49,7 @@ var _ = Context("ToObject", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce dir '%v' to object; incompatible types", providedDir)))
+			Expect(actualErr).To(MatchError("unable to coerce dir 'dummyValue' to object: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {
@@ -66,7 +65,7 @@ var _ = Context("ToObject", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce file to object; error was open nonExistent: no such file or directory")))
+				Expect(actualErr).To(MatchError("unable to coerce file to object: open nonExistent: no such file or directory"))
 			})
 		})
 		Context("ioutil.ReadFile doesn't err", func() {
@@ -88,7 +87,7 @@ var _ = Context("ToObject", func() {
 
 					/* assert */
 					Expect(actualValue).To(BeNil())
-					Expect(actualErr).To(Equal(errors.New("unable to coerce file to object; error was unexpected end of JSON input")))
+					Expect(actualErr).To(MatchError("unable to coerce file to object: unexpected end of JSON input"))
 				})
 			})
 			Context("json.Unmarshal doesn't err", func() {
@@ -139,7 +138,7 @@ var _ = Context("ToObject", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce number '%v' to object; incompatible types", providedNumber)))
+			Expect(actualErr).To(MatchError("unable to coerce number '2.2' to object: incompatible types"))
 		})
 	})
 	Context("Value.Object isn't nil", func() {
@@ -169,7 +168,7 @@ var _ = Context("ToObject", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce string to object; error was unexpected end of JSON input")))
+				Expect(actualErr).To(MatchError("unable to coerce string to object: unexpected end of JSON input"))
 			})
 		})
 		Context("json.Unmarshal doesn't err", func() {
@@ -205,7 +204,7 @@ var _ = Context("ToObject", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to object", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to object"))
 		})
 	})
 })

--- a/sdks/go/data/coerce/toString.go
+++ b/sdks/go/data/coerce/toString.go
@@ -3,9 +3,11 @@ package coerce
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/opctl/opctl/sdks/go/model"
 	"io/ioutil"
 	"strconv"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // ToString coerces a value to a string value
@@ -18,12 +20,12 @@ func ToString(
 	case nil != value.Array:
 		nativeArray, err := value.Unbox()
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce array to string; error was %v", err)
+			return nil, errors.Wrap(err, "unable to coerce array to string")
 		}
 
 		arrayBytes, err := json.Marshal(nativeArray)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce array to string; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce array to string")
 		}
 		arrayString := string(arrayBytes)
 		return &model.Value{String: &arrayString}, nil
@@ -31,11 +33,11 @@ func ToString(
 		booleanString := strconv.FormatBool(*value.Boolean)
 		return &model.Value{String: &booleanString}, nil
 	case nil != value.Dir:
-		return nil, fmt.Errorf("unable to coerce dir '%v' to string; incompatible types", *value.Dir)
+		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to string", *value.Dir))
 	case nil != value.File:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce file to string; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce file to string")
 		}
 		fileString := string(fileBytes)
 		return &model.Value{String: &fileString}, nil
@@ -45,12 +47,12 @@ func ToString(
 	case nil != value.Object:
 		nativeObject, err := value.Unbox()
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to string; error was %v", err)
+			return nil, errors.Wrap(err, "unable to coerce object to string")
 		}
 
 		objectBytes, err := json.Marshal(nativeObject)
 		if nil != err {
-			return nil, fmt.Errorf("unable to coerce object to string; error was %v", err.Error())
+			return nil, errors.Wrap(err, "unable to coerce object to string")
 		}
 		objectString := string(objectBytes)
 		return &model.Value{String: &objectString}, nil

--- a/sdks/go/data/coerce/toString_test.go
+++ b/sdks/go/data/coerce/toString_test.go
@@ -1,8 +1,6 @@
 package coerce
 
 import (
-	"errors"
-	"fmt"
 	"io/ioutil"
 	"strconv"
 
@@ -71,7 +69,7 @@ var _ = Context("ToString", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce dir '%v' to string; incompatible types", providedDir)))
+			Expect(actualErr).To(MatchError("unable to coerce dir 'dummyValue' to string: incompatible types"))
 		})
 	})
 	Context("Value.File isn't nil", func() {
@@ -85,7 +83,7 @@ var _ = Context("ToString", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to coerce file to string; error was open : no such file or directory")))
+				Expect(actualErr).To(MatchError("unable to coerce file to string: open : no such file or directory"))
 			})
 		})
 		Context("ioutil.ReadFile doesn't err", func() {
@@ -181,7 +179,7 @@ var _ = Context("ToString", func() {
 
 			/* assert */
 			Expect(actualValue).To(BeNil())
-			Expect(actualErr).To(Equal(fmt.Errorf("unable to coerce '%+v' to string", providedValue)))
+			Expect(actualErr).To(MatchError("unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to string"))
 		})
 	})
 })

--- a/sdks/go/data/git/pull_test.go
+++ b/sdks/go/data/git/pull_test.go
@@ -86,7 +86,7 @@ var _ = Context("Pull", func() {
 					)
 
 					/* assert */
-					Expect(actualError).To(Equal(expectedError))
+					Expect(actualError).To(MatchError(expectedError))
 				})
 			})
 			Context("err.Error() returns transport.ErrAuthorizationFailed error", func() {
@@ -115,7 +115,7 @@ var _ = Context("Pull", func() {
 					)
 
 					/* assert */
-					Expect(actualError).To(Equal(expectedError))
+					Expect(actualError).To(MatchError(expectedError))
 				})
 			})
 			Context("err.Error() returns other error", func() {

--- a/sdks/go/node/api/client/liveness_test.go
+++ b/sdks/go/node/api/client/liveness_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -86,9 +85,8 @@ var _ = Context("Liveness", func() {
 	Context("StatusCode != 200", func() {
 		It("should return expected result", func() {
 			/* arrange */
-			expectedErr := errors.New("dummyMsg")
 			httpResp := &http.Response{
-				Body:       ioutil.NopCloser(strings.NewReader(expectedErr.Error())),
+				Body:       ioutil.NopCloser(strings.NewReader("dummyMsg")),
 				StatusCode: http.StatusInternalServerError,
 			}
 
@@ -106,7 +104,7 @@ var _ = Context("Liveness", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(expectedErr))
+			Expect(actualErr).To(MatchError("dummyMsg"))
 
 		})
 	})

--- a/sdks/go/node/api/client/pkgs_ref_contents_path_test.go
+++ b/sdks/go/node/api/client/pkgs_ref_contents_path_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -189,7 +188,7 @@ var _ = Context("GetData", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(model.ErrDataRefResolution{}))
+				Expect(actualErr).To(MatchError(model.ErrDataRefResolution{}))
 
 			})
 
@@ -198,9 +197,8 @@ var _ = Context("GetData", func() {
 			It("should return expected result", func() {
 
 				/* arrange */
-				expectedErr := errors.New("dummyMsg")
 				httpResp := &http.Response{
-					Body:       ioutil.NopCloser(strings.NewReader(expectedErr.Error())),
+					Body:       ioutil.NopCloser(strings.NewReader("dummyMsg")),
 					StatusCode: http.StatusInternalServerError,
 				}
 
@@ -218,7 +216,7 @@ var _ = Context("GetData", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(expectedErr))
+				Expect(actualErr).To(MatchError("dummyMsg"))
 
 			})
 

--- a/sdks/go/node/api/client/pkgs_ref_contents_test.go
+++ b/sdks/go/node/api/client/pkgs_ref_contents_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -188,9 +187,8 @@ var _ = Context("ListDescendants", func() {
 			It("should return expected result", func() {
 
 				/* arrange */
-				expectedErr := errors.New("dummyMsg")
 				httpResp := &http.Response{
-					Body:       ioutil.NopCloser(strings.NewReader(expectedErr.Error())),
+					Body:       ioutil.NopCloser(strings.NewReader("dummyMsg")),
 					StatusCode: http.StatusInternalServerError,
 				}
 
@@ -208,7 +206,7 @@ var _ = Context("ListDescendants", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(expectedErr))
+				Expect(actualErr).To(MatchError("dummyMsg"))
 
 			})
 

--- a/sdks/go/node/core/caller.go
+++ b/sdks/go/node/core/caller.go
@@ -256,7 +256,7 @@ func (clr _caller) Call(
 			rootCallID,
 		)
 	default:
-		err = fmt.Errorf("invalid call graph %+v", callSpec)
+		err = fmt.Errorf("invalid call graph '%+v'", callSpec)
 	}
 
 	return outputs, err

--- a/sdks/go/node/core/containerCaller.go
+++ b/sdks/go/node/core/containerCaller.go
@@ -100,7 +100,7 @@ func (cc _containerCaller) Call(
 	}
 
 	if exitCode != 0 {
-		err = fmt.Errorf("nonzero container exit code. Exit code was: %v", exitCode)
+		err = fmt.Errorf("nonzero container exit code: %d", exitCode)
 	}
 
 	// wait on logChan

--- a/sdks/go/node/core/containerCaller_test.go
+++ b/sdks/go/node/core/containerCaller_test.go
@@ -133,7 +133,7 @@ var _ = Context("containerCaller", func() {
 
 				/* assert */
 				Expect(actualOutputs).To(Equal(map[string]*model.Value{}))
-				Expect(actualErr).To(Equal(errors.New(expectedErrorMessage)))
+				Expect(actualErr).To(MatchError(expectedErrorMessage))
 			})
 		})
 	})

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
@@ -1,9 +1,8 @@
 package docker
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -20,7 +19,7 @@ func (ctp _containerRuntime) DeleteContainerIfExists(
 		},
 	)
 	if nil != err {
-		return fmt.Errorf("unable to delete container. Response from docker was: %v", err.Error())
+		return errors.Wrap(err, "unable to delete container")
 	}
 
 	return nil

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
@@ -2,13 +2,12 @@ package docker
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	"github.com/docker/docker/api/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/internal/fakes"
+	"github.com/pkg/errors"
 )
 
 var _ = Context("DeleteContainerIfExists", func() {
@@ -46,15 +45,8 @@ var _ = Context("DeleteContainerIfExists", func() {
 	Context("dockerClient.ContainerRemove errors", func() {
 		It("should return", func() {
 			/* arrange */
-			errorReturnedFromContainerRemove := errors.New("dummyError")
-
 			fakeDockerClient := new(FakeCommonAPIClient)
-			fakeDockerClient.ContainerRemoveReturns(errorReturnedFromContainerRemove)
-
-			expectedError := fmt.Errorf(
-				"unable to delete container. Response from docker was: %v",
-				errorReturnedFromContainerRemove.Error(),
-			)
+			fakeDockerClient.ContainerRemoveReturns(errors.New("dummyError"))
 
 			objectUnderTest := _containerRuntime{
 				dockerClient: fakeDockerClient,
@@ -67,7 +59,7 @@ var _ = Context("DeleteContainerIfExists", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(expectedError))
+			Expect(actualError).To(MatchError("unable to delete container: dummyError"))
 		})
 	})
 	Context("dockerClient.ContainerRemove doesn't error", func() {

--- a/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser.go
+++ b/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser.go
@@ -1,11 +1,9 @@
 package docker
 
 import (
-	"fmt"
-
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	dockerClientPkg "github.com/docker/docker/client"
+	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/singleflight"
 )
@@ -46,8 +44,8 @@ func (ene _ensureNetworkExistser) EnsureNetworkExists(
 		return nil
 	}
 
-	if !client.IsErrNotFound(networkInspectErr) {
-		return fmt.Errorf("unable to inspect network. Response from docker was: %v", networkInspectErr.Error())
+	if !dockerClientPkg.IsErrNotFound(networkInspectErr) {
+		return errors.Wrap(networkInspectErr, "unable to inspect network")
 	}
 
 	// attempt to resolve within singleFlight.Group to ensure concurrent creates don't race
@@ -65,7 +63,7 @@ func (ene _ensureNetworkExistser) EnsureNetworkExists(
 		},
 	)
 	if nil != err {
-		return fmt.Errorf("unable to create network. Response from docker was: %v", err.Error())
+		return errors.Wrap(err, "unable to create network")
 	}
 
 	return nil

--- a/sdks/go/node/core/containerruntime/docker/imagePuller_test.go
+++ b/sdks/go/node/core/containerruntime/docker/imagePuller_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io/ioutil"
+
 	"github.com/docker/docker/api/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
 	. "github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/internal/fakes"
 	. "github.com/opctl/opctl/sdks/go/pubsub/fakes"
-	"io/ioutil"
 )
 
 var _ = Context("imagePuller", func() {
@@ -74,7 +75,7 @@ var _ = Context("imagePuller", func() {
 				)
 
 				/* assert */
-				Expect(actualError).To(Equal(expectedError))
+				Expect(actualError).To(MatchError(expectedError))
 			})
 		})
 	})

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/pubsub"
+	"github.com/pkg/errors"
 )
 
 type runContainer interface {
@@ -216,7 +216,7 @@ func (cr _runContainer) RunContainer(
 	case waitOk := <-waitOkChan:
 		exitCode = waitOk.StatusCode
 	case waitErr := <-waitErrChan:
-		err = fmt.Errorf("error encountered waiting on container; error was: %v", waitErr.Error())
+		err = errors.Wrap(waitErr, "error waiting on container")
 	}
 
 	// ensure stdout, and stderr all read before returning

--- a/sdks/go/node/core/containerruntime/docker/runContainer_test.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer_test.go
@@ -90,7 +90,7 @@ var _ = Context("RunContainer", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(fmt.Errorf("Invalid containerPort: *")))
+			Expect(actualErr).To(MatchError("Invalid containerPort: *"))
 		})
 	})
 	Context("portBindingsFactory.Construct doesn't err", func() {

--- a/sdks/go/node/core/serialCaller_test.go
+++ b/sdks/go/node/core/serialCaller_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"os"
 
 	"io/ioutil"
@@ -81,7 +80,7 @@ var _ = Context("serialCaller", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("image required")))
+				Expect(actualErr).To(MatchError("image required"))
 			})
 		})
 		It("should start each child as expected", func() {

--- a/sdks/go/node/core/serialLoopCaller_test.go
+++ b/sdks/go/node/core/serialLoopCaller_test.go
@@ -2,14 +2,14 @@ package core
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
+
+	"io"
 
 	"github.com/dgraph-io/badger/v2"
 	containerRuntimeFakes "github.com/opctl/opctl/sdks/go/node/core/containerruntime/fakes"
 	. "github.com/opctl/opctl/sdks/go/node/core/internal/fakes"
 	"github.com/opctl/opctl/sdks/go/pubsub"
-	"io"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -150,7 +150,7 @@ var _ = Context("serialLoopCaller", func() {
 					)
 
 					/* assert */
-					Expect(actualErr).To(Equal(errors.New("image required")))
+					Expect(actualErr).To(MatchError("image required"))
 					Expect(actualOutputs).To(BeNil())
 				})
 			})

--- a/sdks/go/opspec/install_test.go
+++ b/sdks/go/opspec/install_test.go
@@ -38,7 +38,7 @@ var _ = Context("Install", func() {
 			actualError := Install(providedCtx, "", fakeHandle)
 
 			/* assert */
-			Expect(actualError).To(Equal(expectedError))
+			Expect(actualError).To(MatchError(expectedError))
 		})
 	})
 	Context("handle.ListDescendants doesn't err", func() {
@@ -88,7 +88,7 @@ var _ = Context("Install", func() {
 				actualError := Install(providedCtx, "", fakeHandle)
 
 				/* assert */
-				Expect(actualError).To(Equal(expectedError))
+				Expect(actualError).To(MatchError(expectedError))
 			})
 		})
 		Context("handle.GetContent doesn't err", func() {

--- a/sdks/go/opspec/interpreter/array/interpret.go
+++ b/sdks/go/opspec/interpreter/array/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to an array value.
@@ -20,7 +21,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to array; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to array", expression))
 	}
 
 	return coerce.ToArray(&v)

--- a/sdks/go/opspec/interpreter/array/interpret_test.go
+++ b/sdks/go/opspec/interpreter/array/interpret_test.go
@@ -1,8 +1,6 @@
 package array
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -19,7 +17,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to array; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to array: unable to interpret '' as reference: '' not in scope"))
 
 		})
 	})

--- a/sdks/go/opspec/interpreter/boolean/interpret.go
+++ b/sdks/go/opspec/interpreter/boolean/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a boolean value.
@@ -19,7 +20,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to boolean; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to boolean", expression))
 	}
 
 	return coerce.ToBoolean(&v)

--- a/sdks/go/opspec/interpreter/boolean/interpret_test.go
+++ b/sdks/go/opspec/interpreter/boolean/interpret_test.go
@@ -1,8 +1,6 @@
 package boolean
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -19,7 +17,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to boolean; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to boolean: unable to interpret '' as reference: '' not in scope"))
 
 		})
 	})

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
@@ -8,6 +8,7 @@ import (
 	"github.com/golang-utils/dircopier"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
+	"github.com/pkg/errors"
 )
 
 // Interpret container dirs
@@ -33,15 +34,14 @@ dirLoop:
 			true,
 		)
 		if nil != err {
-			return nil, fmt.Errorf(
-				"unable to bind %v to %v; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to bind %v to %v",
 				callSpecContainerDirPath,
 				dirExpression,
-				err,
-			)
+			))
 		}
 
-		if "" != *dirValue.Dir && !strings.HasPrefix(*dirValue.Dir, dataCachePath) {
+		if *dirValue.Dir != "" && !strings.HasPrefix(*dirValue.Dir, dataCachePath) {
 			// bound to non dataCachePath
 			containerCallDirs[callSpecContainerDirPath] = *dirValue.Dir
 			continue dirLoop
@@ -55,12 +55,11 @@ dirLoop:
 			*dirValue.Dir,
 			containerCallDirs[callSpecContainerDirPath],
 		); nil != err {
-			return nil, fmt.Errorf(
-				"unable to bind %v to %v; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to bind %v to %v",
 				callSpecContainerDirPath,
 				dirExpression,
-				err,
-			)
+			))
 		}
 
 	}

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
@@ -1,7 +1,6 @@
 package dirs
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -36,7 +35,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to bind /something to $(identifier); error was unable to interpret $(identifier) to dir; error was unable to coerce socket to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to bind /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
 		})
 	})
 	Context("dir.Interpret doesn't err", func() {

--- a/sdks/go/opspec/interpreter/call/container/envvars/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/envvars/interpret.go
@@ -7,6 +7,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/object"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret container envVars
@@ -23,28 +24,26 @@ func Interpret(
 		containerCallSpecEnvVars,
 	)
 	if nil != err {
-		return nil, fmt.Errorf(
-			"unable to interpret '%v' as envVars; error was %v",
+		return nil, errors.Wrap(err, fmt.Sprintf(
+			"unable to interpret '%v' as envVars",
 			containerCallSpecEnvVars,
-			err,
-		)
+		))
 	}
 
 	envVarsStringMap := map[string]string{}
 	for envVarName, envVarValueInterface := range *envVarsMap.Object {
 		envVarValue, err := value.Construct(envVarValueInterface)
 		if nil != err {
-			return nil, fmt.Errorf("unable to construct value for env var %s; error was %v", envVarName, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to construct value for env var '%s'", envVarName))
 		}
 
 		envVarValueString, err := coerce.ToString(envVarValue)
 		if nil != err {
-			return nil, fmt.Errorf(
-				"unable to interpret %+v as value of env var '%v'; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to interpret '%+v' as value of env var '%v'",
 				envVarValue,
 				envVarName,
-				err,
-			)
+			))
 		}
 
 		envVarsStringMap[envVarName] = *envVarValueString.String

--- a/sdks/go/opspec/interpreter/call/container/envvars/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/envvars/interpret_test.go
@@ -1,7 +1,6 @@
 package envvars
 
 import (
-	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -20,7 +19,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret '$()' as envVars; error was unable to interpret $() to object; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret '$()' as envVars: unable to interpret $() to object: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 	Context("object.Interpret doesn't err", func() {
@@ -45,7 +44,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to construct value for env var key; error was unable to construct value; '<nil>' unexpected type")))
+				Expect(actualErr).To(MatchError("unable to construct value for env var 'key': unable to construct value: '<nil>' unexpected type"))
 			})
 		})
 		Context("value.Construct doesn't err", func() {

--- a/sdks/go/opspec/interpreter/call/container/files/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/files/interpret.go
@@ -10,6 +10,7 @@ import (
 	"github.com/golang-utils/filecopier"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/file"
+	"github.com/pkg/errors"
 )
 
 // Interpret container files
@@ -35,12 +36,11 @@ fileLoop:
 			true,
 		)
 		if nil != err {
-			return nil, fmt.Errorf(
-				"unable to bind %v to %v; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to bind %v to %v",
 				callSpecContainerFilePath,
 				fileExpression,
-				err,
-			)
+			))
 		}
 
 		if !strings.HasPrefix(*fileValue.File, dataCachePath) {
@@ -57,12 +57,11 @@ fileLoop:
 			filepath.Dir(containerCallFiles[callSpecContainerFilePath]),
 			0777,
 		); nil != err {
-			return nil, fmt.Errorf(
-				"unable to bind %v to %v; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to bind %v to %v",
 				callSpecContainerFilePath,
 				fileExpression,
-				err,
-			)
+			))
 		}
 
 		// copy file
@@ -72,12 +71,11 @@ fileLoop:
 			containerCallFiles[callSpecContainerFilePath],
 		)
 		if nil != err {
-			return nil, fmt.Errorf(
-				"unable to bind %v to %v; error was %v",
+			return nil, errors.Wrap(err, fmt.Sprintf(
+				"unable to bind %v to %v",
 				callSpecContainerFilePath,
 				fileExpression,
-				err,
-			)
+			))
 		}
 
 	}

--- a/sdks/go/opspec/interpreter/call/container/files/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/files/interpret_test.go
@@ -1,7 +1,6 @@
 package files
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -32,7 +31,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to bind /somewhere to $(identifier); error was unable to coerce '{\"socket\":\"\"}' to file")))
+			Expect(actualErr).To(MatchError("unable to bind /somewhere to $(identifier): unable to coerce '{\"socket\":\"\"}' to file"))
 		})
 	})
 	Context("value.File not prefixed by dataDirPath", func() {

--- a/sdks/go/opspec/interpreter/call/container/image/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/image/interpret.go
@@ -1,13 +1,13 @@
 package image
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
+	"github.com/pkg/errors"
 )
 
 // Interpret container image
@@ -18,7 +18,7 @@ func Interpret(
 ) (*model.ContainerCallImage, error) {
 
 	if nil == containerCallImageSpec {
-		return nil, fmt.Errorf("image required")
+		return nil, errors.New("image required")
 	}
 
 	// try to interpret as dir
@@ -55,12 +55,12 @@ func Interpret(
 	if nil != containerCallImageSpec.PullCreds {
 		username, err := str.Interpret(scope, containerCallImageSpec.PullCreds.Username)
 		if nil != err {
-			return nil, fmt.Errorf("error encountered interpreting image pullcreds username; error was: %v", err)
+			return nil, errors.Wrap(err, "error encountered interpreting image pullcreds username")
 		}
 
 		password, err := str.Interpret(scope, containerCallImageSpec.PullCreds.Password)
 		if nil != err {
-			return nil, fmt.Errorf("error encountered interpreting image pullcreds password; error was: %v", err)
+			return nil, errors.Wrap(err, "error encountered interpreting image pullcreds password")
 		}
 
 		containerCallImage.PullCreds = &model.Creds{

--- a/sdks/go/opspec/interpreter/call/container/image/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/image/interpret_test.go
@@ -22,7 +22,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(fmt.Errorf("image required")))
+			Expect(actualError).To(MatchError("image required"))
 		})
 	})
 	Context("containerCallImageSpec isn't nil", func() {
@@ -37,13 +37,13 @@ var _ = Context("Interpret", func() {
 			passwordValue := "passwordValue"
 
 			providedScope := map[string]*model.Value{
-				usernameVariable: &model.Value{
+				usernameVariable: {
 					String: &usernameValue,
 				},
-				passwordVariable: &model.Value{
+				passwordVariable: {
 					String: &passwordValue,
 				},
-				refVariable: &model.Value{
+				refVariable: {
 					String: &refValue,
 				},
 			}

--- a/sdks/go/opspec/interpreter/call/container/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret_test.go
@@ -1,7 +1,6 @@
 package container
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -36,7 +35,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to string; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 
@@ -70,7 +69,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to bind /something to $(identifier); error was unable to interpret $(identifier) to dir; error was unable to coerce socket to dir; incompatible types")))
+			Expect(actualErr).To(MatchError("unable to bind /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
 		})
 	})
 
@@ -97,7 +96,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret '$()' as envVars; error was unable to interpret $() to object; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret '$()' as envVars: unable to interpret $() to object: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 
@@ -130,7 +129,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to bind /something to $(not); error was unable to coerce '{\"socket\":\"\"}' to file")))
+			Expect(actualErr).To(MatchError("unable to bind /something to $(not): unable to coerce '{\"socket\":\"\"}' to file"))
 		})
 	})
 
@@ -156,7 +155,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to string; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 

--- a/sdks/go/opspec/interpreter/call/interpret.go
+++ b/sdks/go/opspec/interpreter/call/interpret.go
@@ -88,6 +88,6 @@ func Interpret(
 		)
 		return call, err
 	default:
-		return nil, fmt.Errorf("invalid call graph %+v", callSpec)
+		return nil, fmt.Errorf("invalid call graph '%+v'", callSpec)
 	}
 }

--- a/sdks/go/opspec/interpreter/call/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/interpret_test.go
@@ -2,7 +2,6 @@ package call
 
 import (
 	"context"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -40,7 +39,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualError).To(Equal(errors.New("unable to interpret predicate; predicate was unexpected type &{Eq:<nil> Exists:<nil> Ne:<nil> NotExists:<nil>}")))
+				Expect(actualError).To(MatchError("unable to interpret predicate: predicate was unexpected type &{Eq:<nil> Exists:<nil> Ne:<nil> NotExists:<nil>}"))
 			})
 		})
 	})

--- a/sdks/go/opspec/interpreter/call/loop/iteration/scope_test.go
+++ b/sdks/go/opspec/interpreter/call/loop/iteration/scope_test.go
@@ -1,8 +1,6 @@
 package iteration
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -60,7 +58,7 @@ var _ = Context("Scope", func() {
 					)
 
 					/* assert */
-					Expect(actualErr).To(Equal(errors.New("unable to coerce string to object; error was invalid character 'p' looking for beginning of value")))
+					Expect(actualErr).To(MatchError("unable to coerce string to object: invalid character 'p' looking for beginning of value"))
 				})
 			})
 		})

--- a/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/object"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
+	"github.com/pkg/errors"
 )
 
 //Interpret interprets an op input
@@ -24,14 +25,14 @@ func Interpret(
 ) (*model.Value, error) {
 
 	if nil == param {
-		return nil, fmt.Errorf("unable to bind to '%v'; '%v' not a defined input", name, name)
+		return nil, fmt.Errorf("unable to bind to '%v': '%v' not a defined input", name, name)
 	}
 
 	if nil == valueExpression || "" == valueExpression {
 		// implicitly bound
 		_, ok := scope[name]
 		if !ok {
-			return nil, fmt.Errorf("unable to bind to '%v' via implicit ref; '%v' not in scope", name, name)
+			return nil, fmt.Errorf("unable to bind to '%v' via implicit ref: '%v' not in scope", name, name)
 		}
 		valueExpression = fmt.Sprintf("$(%v)", name)
 	}
@@ -40,57 +41,57 @@ func Interpret(
 	case nil != param.Array:
 		arrayValue, err := array.Interpret(scope, valueExpression)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return arrayValue, nil
 	case nil != param.Boolean:
 		booleanValue, err := boolean.Interpret(scope, valueExpression)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return booleanValue, nil
 	case nil != param.File:
 		fileValue, err := file.Interpret(scope, valueExpression, opScratchDir, true)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return fileValue, nil
 	case nil != param.Dir:
 		dirValue, err := dir.Interpret(scope, valueExpression, opScratchDir, true)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return dirValue, nil
 	case nil != param.Number:
 		numberValue, err := number.Interpret(scope, valueExpression)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return numberValue, nil
 	case nil != param.Object:
 		objectValue, err := object.Interpret(scope, valueExpression)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return objectValue, nil
 	case nil != param.String:
 		stringValue, err := str.Interpret(scope, valueExpression)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		return stringValue, nil
 	case nil != param.Socket:
 		stringValueExpression, isString := valueExpression.(string)
 		if !isString {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; sockets must be passed by reference", name, valueExpression)
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': sockets must be passed by reference", name, valueExpression)
 		}
 
 		socketValue, err := reference.Interpret(stringValueExpression, scope, nil)
 		if nil != err {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; error was: '%v'", name, valueExpression, err.Error())
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
 		}
 		if nil == socketValue.Socket {
-			return nil, fmt.Errorf("unable to bind '%v' to '%+v'; '%+v' must reference a socket", name, valueExpression, valueExpression)
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': '%+v' must reference a socket", name, valueExpression, valueExpression)
 		}
 
 		return socketValue, nil

--- a/sdks/go/opspec/interpreter/call/op/inputs/input/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/op/inputs/input/interpret_test.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -23,7 +22,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedName := "dummyName"
 
-			expectedError := fmt.Errorf("unable to bind to '%v'; '%v' not a defined input", providedName, providedName)
+			expectedError := fmt.Sprintf("unable to bind to '%v': '%v' not a defined input", providedName, providedName)
 
 			/* act */
 			_, actualError := Interpret(
@@ -35,7 +34,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(expectedError))
+			Expect(actualError).To(MatchError(expectedError))
 		})
 	})
 	Context("Implicit arg", func() {
@@ -44,7 +43,7 @@ var _ = Context("Interpret", func() {
 				/* arrange */
 				providedName := "dummyName"
 
-				expectedError := fmt.Errorf("unable to bind to '%v' via implicit ref; '%v' not in scope", providedName, providedName)
+				expectedError := fmt.Sprintf("unable to bind to '%v' via implicit ref: '%v' not in scope", providedName, providedName)
 
 				/* act */
 				_, actualError := Interpret(
@@ -56,7 +55,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualError).To(Equal(expectedError))
+				Expect(actualError).To(MatchError(expectedError))
 			})
 		})
 	})
@@ -65,7 +64,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected results", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Array: new([]interface{})},
+					name: {Array: new([]interface{})},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 
@@ -92,7 +91,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected results", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Boolean: new(bool)},
+					name: {Boolean: new(bool)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 
@@ -119,7 +118,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected results", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Dir: new(string)},
+					name: {Dir: new(string)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 				providedScratchDirPath := "dummyScratchDir"
@@ -147,7 +146,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected results", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{File: new(string)},
+					name: {File: new(string)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 				providedScratchDirPath := "dummyScratchDir"
@@ -175,7 +174,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected results", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Number: new(float64)},
+					name: {Number: new(float64)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 
@@ -202,7 +201,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected result", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Object: new(map[string]interface{})},
+					name: {Object: new(map[string]interface{})},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 
@@ -229,7 +228,7 @@ var _ = Context("Interpret", func() {
 			It("should return expected result", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{String: new(string)},
+					name: {String: new(string)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 
@@ -267,13 +266,13 @@ var _ = Context("Interpret", func() {
 					)
 
 					/* assert */
-					Expect(actualError).To(Equal(errors.New("unable to bind 'name' to '$(name)'; error was: 'unable to interpret $(name) to array; error was unable to interpret 'name' as reference; 'name' not in scope'")))
+					Expect(actualError).To(MatchError("unable to bind 'name' to '$(name)': unable to interpret $(name) to array: unable to interpret 'name' as reference: 'name' not in scope"))
 				})
 			})
 			It("should return expected result", func() {
 				name := "name"
 				providedScope := map[string]*model.Value{
-					name: &model.Value{Socket: new(string)},
+					name: {Socket: new(string)},
 				}
 				providedExpression := fmt.Sprintf("$(%s)", name)
 

--- a/sdks/go/opspec/interpreter/call/op/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/interpret.go
@@ -15,6 +15,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
+	"github.com/pkg/errors"
 )
 
 // Interpret interprets an OpCallSpec into a OpCall
@@ -56,7 +57,7 @@ func Interpret(
 			false,
 		)
 		if nil != err {
-			return nil, fmt.Errorf("error encountered interpreting image src; error was: %v", err)
+			return nil, errors.Wrap(err, "error encountered interpreting image src")
 		}
 		opPath = *dirValue.Dir
 	} else {
@@ -102,7 +103,7 @@ func Interpret(
 		scratchDirPath,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret call to %v; error was: %v", opCallSpec.Ref, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret call to %v", opCallSpec.Ref))
 	}
 
 	return opCall, nil

--- a/sdks/go/opspec/interpreter/call/op/params/coercer.go
+++ b/sdks/go/opspec/interpreter/call/op/params/coercer.go
@@ -48,7 +48,7 @@ paramLoop:
 			coercedValues[paramName] = value
 			continue paramLoop
 		default:
-			err = fmt.Errorf("unable to coerce arg; param was unexpected type %+v", paramValue)
+			err = fmt.Errorf("unable to coerce arg: param was unexpected type %+v", paramValue)
 		}
 
 		if nil != err {

--- a/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
@@ -2,13 +2,13 @@ package array
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
+	"strings"
+
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
-	"strings"
 )
 
 // Validate validates a value against a string parameter
@@ -35,7 +35,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating parameter. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 
@@ -47,7 +47,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating param. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 

--- a/sdks/go/opspec/interpreter/call/op/params/param/number/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/number/validate.go
@@ -2,13 +2,12 @@ package number
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -34,7 +33,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating parameter. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 
@@ -46,7 +45,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating param. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 

--- a/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
@@ -2,13 +2,12 @@ package object
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -37,7 +36,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating parameter. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 
@@ -49,7 +48,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating param. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 

--- a/sdks/go/opspec/interpreter/call/op/params/param/str/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/str/validate.go
@@ -2,13 +2,13 @@ package str
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
+	"strings"
+
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
+	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
-	"strings"
 )
 
 // Validate validates a value against a number parameter
@@ -36,7 +36,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating parameter. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 
@@ -48,7 +48,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				fmt.Errorf("error validating param. Details: %v", err.Error()),
+				errors.Wrap(err, "error validating parameter"),
 			)
 		}
 

--- a/sdks/go/opspec/interpreter/call/op/params/param/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/validate.go
@@ -43,6 +43,6 @@ func Validate(
 	case nil != param.Socket:
 		return socket.Validate(value)
 	default:
-		return []error{fmt.Errorf("unable to validate value; param was unexpected type %+v", param)}
+		return []error{fmt.Errorf("unable to validate value: param was unexpected type %+v", param)}
 	}
 }

--- a/sdks/go/opspec/interpreter/call/op/params/validator_test.go
+++ b/sdks/go/opspec/interpreter/call/op/params/validator_test.go
@@ -1,7 +1,6 @@
 package params
 
 import (
-	"errors"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -34,6 +33,6 @@ var _ = Context("Validate", func() {
 		)
 
 		/* assert */
-		Expect(actualErr).To(Equal(errors.New("\n-\n  validation error(s):\n\n    - expectedName1: String length must be greater than or equal to 10\n\n-")))
+		Expect(actualErr).To(MatchError("\n-\n  validation error(s):\n\n    - expectedName1: String length must be greater than or equal to 10\n\n-"))
 	})
 })

--- a/sdks/go/opspec/interpreter/call/parallelloop/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/parallelloop/interpret_test.go
@@ -1,7 +1,6 @@
 package parallelloop
 
 import (
-	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -22,7 +21,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(errors.New("unable to coerce string to object; error was invalid character 'r' looking for beginning of value")))
+			Expect(actualError).To(MatchError("unable to coerce string to object: invalid character 'r' looking for beginning of value"))
 		})
 	})
 	It("should return expected result", func() {

--- a/sdks/go/opspec/interpreter/call/predicates/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/predicates/interpret_test.go
@@ -1,8 +1,6 @@
 package predicates
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -18,15 +16,13 @@ var _ = Context("Interpret", func() {
 			/* act */
 			_, actualError := Interpret(
 				[]*model.PredicateSpec{
-					&model.PredicateSpec{
-						Eq: &eqPredicate,
-					},
+					{Eq: &eqPredicate},
 				},
 				map[string]*model.Value{},
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(errors.New("unable to interpret $() to string; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualError).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 	Context("predicateInterpreter.Interpret returns true", func() {
@@ -40,7 +36,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			actualResult, _ := Interpret(
 				[]*model.PredicateSpec{
-					&model.PredicateSpec{Eq: &eqPredicate},
+					{Eq: &eqPredicate},
 				},
 				map[string]*model.Value{},
 			)
@@ -60,7 +56,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			actualResult, _ := Interpret(
 				[]*model.PredicateSpec{
-					&model.PredicateSpec{Eq: &eqPredicate},
+					{Eq: &eqPredicate},
 				},
 				map[string]*model.Value{},
 			)

--- a/sdks/go/opspec/interpreter/call/predicates/predicate/eq/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/predicates/predicate/eq/interpret_test.go
@@ -1,8 +1,6 @@
 package eq
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -19,7 +17,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(errors.New("unable to interpret <nil> to string; error was unable to interpret <nil> as value; unsupported type")))
+			Expect(actualError).To(MatchError("unable to interpret <nil> to string: unable to interpret <nil> as value: unsupported type"))
 		})
 	})
 	Context("str.Interpret returns equal items", func() {

--- a/sdks/go/opspec/interpreter/call/predicates/predicate/interpret.go
+++ b/sdks/go/opspec/interpreter/call/predicates/predicate/interpret.go
@@ -37,6 +37,6 @@ func Interpret(
 			scope,
 		)
 	default:
-		return false, fmt.Errorf("unable to interpret predicate; predicate was unexpected type %+v", predicateSpec)
+		return false, fmt.Errorf("unable to interpret predicate: predicate was unexpected type %+v", predicateSpec)
 	}
 }

--- a/sdks/go/opspec/interpreter/call/predicates/predicate/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/predicates/predicate/interpret_test.go
@@ -96,7 +96,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedScgPredicate := &model.PredicateSpec{}
 
-			expectedError := fmt.Errorf("unable to interpret predicate; predicate was unexpected type %+v", providedScgPredicate)
+			expectedError := fmt.Errorf("unable to interpret predicate: predicate was unexpected type %+v", providedScgPredicate)
 
 			/* act */
 			_, actualError := Interpret(
@@ -105,7 +105,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(expectedError))
+			Expect(actualError).To(MatchError(expectedError))
 		})
 	})
 })

--- a/sdks/go/opspec/interpreter/call/predicates/predicate/ne/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/predicates/predicate/ne/interpret_test.go
@@ -1,8 +1,6 @@
 package ne
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -19,7 +17,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualError).To(Equal(errors.New("unable to interpret $() to string; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualError).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 	Context("str.Interpret returns equal items", func() {

--- a/sdks/go/opspec/interpreter/dir/interpret.go
+++ b/sdks/go/opspec/interpreter/dir/interpret.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a dir value.
@@ -41,12 +42,12 @@ func Interpret(
 				opts,
 			)
 			if nil != err {
-				return nil, fmt.Errorf("unable to interpret %+v to dir; error was %v", expression, err)
+				return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
 			}
 
 			result, err := coerce.ToDir(value, scratchDir)
 			if nil != err {
-				err = fmt.Errorf("unable to interpret %+v to dir; error was %v", expression, err)
+				err = errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
 			}
 			return result, err
 
@@ -58,13 +59,12 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to dir; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
 	}
 
 	result, err := coerce.ToDir(&value, scratchDir)
 	if nil != err {
-		err = fmt.Errorf("unable to interpret %+v to dir; error was %v", expression, err)
+		err = errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
 	}
 	return result, err
-
 }

--- a/sdks/go/opspec/interpreter/dir/interpret_test.go
+++ b/sdks/go/opspec/interpreter/dir/interpret_test.go
@@ -1,7 +1,6 @@
 package dir
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -34,7 +33,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to interpret $(identifier) to dir; error was unable to coerce socket to dir; incompatible types")))
+				Expect(actualErr).To(MatchError("unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
 
 			})
 		})
@@ -61,7 +60,7 @@ var _ = Context("Interpret", func() {
 					)
 
 					/* assert */
-					Expect(actualErr).To(Equal(errors.New("unable to interpret $(identifier) to dir; error was unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to dir")))
+					Expect(actualErr).To(MatchError("unable to interpret $(identifier) to dir: unable to coerce '&{Array:<nil> Boolean:<nil> Dir:<nil> File:<nil> Number:<nil> Object:<nil> Socket:<nil> String:<nil>}' to dir"))
 				})
 			})
 			Context("value.Dir not nil", func() {

--- a/sdks/go/opspec/interpreter/file/interpret.go
+++ b/sdks/go/opspec/interpreter/file/interpret.go
@@ -5,15 +5,13 @@ import (
 	"regexp"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
+	"github.com/pkg/errors"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
 )
 
-var fileType = "File"
-
-//
 // Interpret an expression to a file value.
 // Expression must be a type supported by coerce.ToFile
 // scratchDir will be used as the containing dir if file creation necessary
@@ -46,7 +44,7 @@ func Interpret(
 			opts,
 		)
 		if nil != err {
-			return nil, fmt.Errorf("unable to interpret %+v to file; error was %v", expression, err)
+			return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to file", expression))
 		}
 		return coerce.ToFile(value, scratchDir)
 	}
@@ -56,7 +54,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to file; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to file", expression))
 	}
 
 	return coerce.ToFile(&value, scratchDir)

--- a/sdks/go/opspec/interpreter/file/interpret_test.go
+++ b/sdks/go/opspec/interpreter/file/interpret_test.go
@@ -1,7 +1,6 @@
 package file
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -25,7 +24,7 @@ var _ = Context("Interpret", func() {
 
 				/* assert */
 				Expect(actualValue).To(BeNil())
-				Expect(actualErr).To(Equal(errors.New("unable to interpret $() to file; error was unable to interpret '' as reference; '' not in scope")))
+				Expect(actualErr).To(MatchError("unable to interpret $() to file: unable to interpret '' as reference: '' not in scope"))
 			})
 		})
 		Context("reference.Interpret doesn't error", func() {
@@ -71,7 +70,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret <nil> to file; error was unable to interpret <nil> as value; unsupported type")))
+			Expect(actualErr).To(MatchError("unable to interpret <nil> to file: unable to interpret <nil> as value: unsupported type"))
 		})
 	})
 	Context("value.Interpret doesn't err", func() {

--- a/sdks/go/opspec/interpreter/interpolater/interpolate_test.go
+++ b/sdks/go/opspec/interpreter/interpolater/interpolate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data"
 	"github.com/opctl/opctl/sdks/go/data/fs"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 var _ = Context("Interpolate", func() {
@@ -39,17 +40,17 @@ var _ = Context("Interpolate", func() {
 								Expected string
 							}{}
 							if err := yaml.Unmarshal(scenariosOpFileBytes, &scenarioOpFile); nil != err {
-								panic(fmt.Errorf("error unmarshalling scenario.yml for %v; error was %v", path, err))
+								panic(errors.Wrap(err, "error unmarshalling scenario.yml for "+path))
 							}
 
 							absPath, err := filepath.Abs(path)
 							if nil != err {
-								panic(fmt.Errorf("error getting absPath for %v; error was %v", path, err))
+								panic(errors.Wrap(err, "error getting absPath for "+path))
 							}
 
 							opHandle, err := data.Resolve(context.Background(), absPath, fsProvider)
 							if nil != err {
-								panic(fmt.Errorf("error getting opHandle for %v; error was %v", path, err))
+								panic(errors.Wrap(err, "error getting opHandle for "+path))
 							}
 
 							for _, scenario := range scenarioOpFile {

--- a/sdks/go/opspec/interpreter/number/interpret.go
+++ b/sdks/go/opspec/interpreter/number/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a number value.
@@ -20,7 +21,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to number; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to number", expression))
 	}
 
 	return coerce.ToNumber(&v)

--- a/sdks/go/opspec/interpreter/number/interpret_test.go
+++ b/sdks/go/opspec/interpreter/number/interpret_test.go
@@ -1,7 +1,6 @@
 package number
 
 import (
-	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -19,7 +18,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to number; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to number: unable to interpret '' as reference: '' not in scope"))
 
 		})
 	})

--- a/sdks/go/opspec/interpreter/object/interpret.go
+++ b/sdks/go/opspec/interpreter/object/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to an object value.
@@ -20,7 +21,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to object; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to object", expression))
 	}
 
 	return coerce.ToObject(&value)

--- a/sdks/go/opspec/interpreter/object/interpret_test.go
+++ b/sdks/go/opspec/interpreter/object/interpret_test.go
@@ -1,8 +1,6 @@
 package object
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -19,7 +17,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to object; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to object: unable to interpret '' as reference: '' not in scope"))
 
 		})
 	})

--- a/sdks/go/opspec/interpreter/reference/direntry/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/direntry/interpret.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/pkg/errors"
 )
 
 // Interpret a dir entry ref i.e. refs of the form name/sub/file.ext
@@ -19,7 +20,7 @@ func Interpret(
 ) (string, *model.Value, error) {
 
 	if !strings.HasPrefix(ref, "/") {
-		return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref; expected '/'", ref)
+		return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: expected '/'", ref)
 	}
 
 	valuePath := filepath.Join(*data.Dir, ref)
@@ -36,7 +37,7 @@ func Interpret(
 		if "Dir" == *opts {
 			err := os.MkdirAll(valuePath, 0700)
 			if nil != err {
-				return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref; error was %v", ref, err)
+				return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
 			}
 
 			return "", &model.Value{Dir: &valuePath}, nil
@@ -45,19 +46,19 @@ func Interpret(
 		// handle file ref
 		err := os.MkdirAll(filepath.Dir(valuePath), 0700)
 		if nil != err {
-			return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref; error was %v", ref, err)
+			return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
 		}
 
 		file, err := os.Create(valuePath)
 		file.Close()
 		if nil != err {
-			return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref; error was %v", ref, err)
+			return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
 		}
 
 		return "", &model.Value{File: &valuePath}, nil
 
 	}
 
-	return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref; error was %v", ref, err)
+	return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
 
 }

--- a/sdks/go/opspec/interpreter/reference/direntry/interpret_test.go
+++ b/sdks/go/opspec/interpreter/reference/direntry/interpret_test.go
@@ -17,7 +17,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedRef := "dummyRef"
 
-			expectedErr := fmt.Errorf("unable to interpret '%v' as dir entry ref; expected '/'", providedRef)
+			expectedErr := fmt.Errorf("unable to interpret '%v' as dir entry ref: expected '/'", providedRef)
 
 			/* act */
 			_, _, actualErr := Interpret(

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/bracketed/item"
+	"github.com/pkg/errors"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
 
@@ -20,17 +21,17 @@ func Interpret(
 ) (string, *model.Value, error) {
 
 	if !strings.HasPrefix(ref, "[") {
-		return "", nil, fmt.Errorf("unable to interpret '%v'; expected '['", ref)
+		return "", nil, fmt.Errorf("unable to interpret '%v': expected '['", ref)
 	}
 
 	indexOfNextCloseBracket := strings.Index(ref, "]")
 	if indexOfNextCloseBracket < 0 {
-		return "", nil, fmt.Errorf("unable to interpret '%v'; expected ']'", ref)
+		return "", nil, fmt.Errorf("unable to interpret '%v': expected ']'", ref)
 	}
 
 	data, err := CoerceToArrayOrObject(data)
 	if nil != err {
-		return "", nil, fmt.Errorf("unable to interpret '%v'; error was %v", ref, err.Error())
+		return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
 	}
 
 	identifier := ref[1:indexOfNextCloseBracket]
@@ -50,7 +51,7 @@ func Interpret(
 	property := (*data.Object)[identifier]
 	propertyValue, err := value.Construct(property)
 	if nil != err {
-		return "", nil, fmt.Errorf("unable to interpret property; error was %v", err.Error())
+		return "", nil, errors.Wrap(err, "unable to interpret property")
 	}
 	return refRemainder, propertyValue, nil
 }

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret_test.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret_test.go
@@ -1,7 +1,6 @@
 package bracketed
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/bracketed/item"
@@ -18,7 +17,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedRef := "dummyRef"
 
-			expectedErr := fmt.Errorf("unable to interpret '%v'; expected '['", providedRef)
+			expectedErr := fmt.Errorf("unable to interpret '%v': expected '['", providedRef)
 
 			/* act */
 			_, _, actualErr := Interpret(
@@ -35,7 +34,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			providedRef := "[dummyRef"
 
-			expectedErr := fmt.Errorf("unable to interpret '%v'; expected ']'", providedRef)
+			expectedErr := fmt.Errorf("unable to interpret '%v': expected ']'", providedRef)
 
 			/* act */
 			_, _, actualErr := Interpret(
@@ -62,7 +61,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret '[]'; error was unable to coerce string to object; error was unexpected end of JSON input")))
+			Expect(actualErr).To(MatchError("unable to interpret '[]': unable to coerce string to object: unexpected end of JSON input"))
 		})
 	})
 	Context("data is array", func() {
@@ -83,7 +82,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to interpret item; error was strconv.ParseInt: parsing \"dummyIdentifier\": invalid syntax")))
+				Expect(actualErr).To(MatchError("unable to interpret item: strconv.ParseInt: parsing \"dummyIdentifier\": invalid syntax"))
 			})
 		})
 		Context("item.Interpret doesn't err", func() {
@@ -133,7 +132,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to interpret property; error was unable to construct value; '<nil>' unexpected type")))
+				Expect(actualErr).To(MatchError("unable to interpret property: unable to construct value: '<nil>' unexpected type"))
 			})
 		})
 		Context("value.Construct doesn't err", func() {

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret.go
@@ -1,9 +1,9 @@
 package item
 
 import (
-	"fmt"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an item from data via indexString.
@@ -14,13 +14,13 @@ func Interpret(
 ) (*model.Value, error) {
 	itemIndex, err := ParseIndex(indexString, *data.Array)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret item; error was %v", err.Error())
+		return nil, errors.Wrap(err, "unable to interpret item")
 	}
 
 	item := (*data.Array)[itemIndex]
 	itemValue, err := value.Construct(item)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret item; error was %v", err.Error())
+		return nil, errors.Wrap(err, "unable to interpret item")
 	}
 
 	return itemValue, nil

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret_test.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret_test.go
@@ -1,8 +1,6 @@
 package item
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -21,7 +19,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret item; error was strconv.ParseInt: parsing \"dummyIndexString\": invalid syntax")))
+			Expect(actualErr).To(MatchError("unable to interpret item: strconv.ParseInt: parsing \"dummyIndexString\": invalid syntax"))
 		})
 	})
 	Context("parseIndexer.ParseIndex doesn't err", func() {
@@ -41,7 +39,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to interpret item; error was unable to construct value; '<nil>' unexpected type")))
+				Expect(actualErr).To(MatchError("unable to interpret item: unable to construct value: '<nil>' unexpected type"))
 			})
 		})
 		Context("value.Construct doesn't err", func() {

--- a/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an unbracketed identifier from ref as determined by unbracketed/parse.go
@@ -17,19 +18,19 @@ func Interpret(
 
 	dataAsObject, err := coerce.ToObject(data)
 	if nil != err {
-		return ref, nil, fmt.Errorf("unable to interpret '%v'; error was %v", ref, err.Error())
+		return ref, nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
 	}
 
 	identifier, refRemainder := Parse(ref)
 
 	scopeValue, isValueInScope := (*dataAsObject.Object)[identifier]
 	if !isValueInScope {
-		return ref, nil, fmt.Errorf("unable to interpret '%v'; '%v' doesn't exist", ref, identifier)
+		return ref, nil, fmt.Errorf("unable to interpret '%v': '%v' doesn't exist", ref, identifier)
 	}
 
 	identifierValue, err := value.Construct(scopeValue)
 	if nil != err {
-		return ref, nil, fmt.Errorf("unable to interpret '%v'; error was %v", ref, err.Error())
+		return ref, nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
 	}
 
 	return refRemainder, identifierValue, nil

--- a/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret_test.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret_test.go
@@ -1,7 +1,6 @@
 package unbracketed
 
 import (
-	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
@@ -25,7 +24,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret 'dummyRef'; error was unable to coerce string to object; error was unexpected end of JSON input")))
+			Expect(actualErr).To(MatchError("unable to interpret 'dummyRef': unable to coerce string to object: unexpected end of JSON input"))
 		})
 	})
 	Context("coerce.ToObject doesn't err", func() {
@@ -39,7 +38,7 @@ var _ = Context("Interpret", func() {
 
 				objectData := map[string]interface{}{}
 
-				expectedErr := fmt.Errorf("unable to interpret '%v'; '%v' doesn't exist", providedRef, identifier)
+				expectedErr := fmt.Errorf("unable to interpret '%v': '%v' doesn't exist", providedRef, identifier)
 
 				/* act */
 				_, _, actualErr := Interpret(
@@ -70,7 +69,7 @@ var _ = Context("Interpret", func() {
 					)
 
 					/* assert */
-					Expect(actualErr).To(Equal(errors.New("unable to interpret 'identifier.'; error was unable to construct value; '<nil>' unexpected type")))
+					Expect(actualErr).To(MatchError("unable to interpret 'identifier.': unable to construct value: '<nil>' unexpected type"))
 				})
 			})
 			Context("value.Construct doesn't err", func() {

--- a/sdks/go/opspec/interpreter/reference/identifier/value/construct.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/value/construct.go
@@ -2,6 +2,7 @@ package value
 
 import (
 	"fmt"
+
 	"github.com/opctl/opctl/sdks/go/model"
 )
 
@@ -24,6 +25,6 @@ func Construct(
 	case []interface{}:
 		return &model.Value{Array: &data}, nil
 	default:
-		return nil, fmt.Errorf("unable to construct value; '%v' unexpected type", data)
+		return nil, fmt.Errorf("unable to construct value: '%v' unexpected type", data)
 	}
 }

--- a/sdks/go/opspec/interpreter/reference/identifier/value/construct_test.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/value/construct_test.go
@@ -1,8 +1,6 @@
 package value
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -90,14 +88,11 @@ var _ = Context("Construct", func() {
 	})
 	Context("data is unexpected type", func() {
 		It("should return expected result", func() {
-			/* arrange */
-			expectedErr := fmt.Errorf("unable to construct value; '%+v' unexpected type", nil)
-
 			/* act */
 			_, actualErr := Construct(nil)
 
 			/* assert */
-			Expect(actualErr).To(Equal(expectedErr))
+			Expect(actualErr).To(MatchError("unable to construct value: '<nil>' unexpected type"))
 		})
 	})
 })

--- a/sdks/go/opspec/interpreter/reference/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/interpret.go
@@ -86,7 +86,7 @@ func interpolate(
 			nestedRefStartIndex := i + len(RefStart)
 			nestedRefEndBracketOffset := strings.Index(ref[nestedRefStartIndex:], RefEnd)
 			if nestedRefEndBracketOffset < 0 {
-				return "", fmt.Errorf("unable to interpret '%v' as reference; expected ')'", ref[i:])
+				return "", fmt.Errorf("unable to interpret '%v' as reference: expected ')'", ref[i:])
 			}
 			nestedRefEndBracketIndex := nestedRefStartIndex + nestedRefEndBracketOffset
 			nestedRef := ref[nestedRefStartIndex:nestedRefEndBracketIndex]
@@ -171,7 +171,7 @@ func getRootValue(
 		}
 	}
 
-	return nil, "", fmt.Errorf("unable to interpret '%v' as reference; '%v' not in scope", ref, identifier)
+	return nil, "", fmt.Errorf("unable to interpret '%v' as reference: '%v' not in scope", ref, identifier)
 }
 
 // rInterpret interprets refs of the form:
@@ -218,7 +218,7 @@ func rInterpret(
 
 		return rInterpret(ref, data, opts)
 	default:
-		return "", nil, fmt.Errorf("unable to interpret '%v' as reference; expected '[', '.', or '/'", ref)
+		return "", nil, fmt.Errorf("unable to interpret '%v' as reference: expected '[', '.', or '/'", ref)
 	}
 
 }

--- a/sdks/go/opspec/interpreter/str/interpret.go
+++ b/sdks/go/opspec/interpreter/str/interpret.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a string value.
@@ -18,7 +19,7 @@ func Interpret(
 		scope,
 	)
 	if nil != err {
-		return nil, fmt.Errorf("unable to interpret %+v to string; error was %v", expression, err)
+		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to string", expression))
 	}
 
 	return coerce.ToString(&v)

--- a/sdks/go/opspec/interpreter/str/interpret_test.go
+++ b/sdks/go/opspec/interpreter/str/interpret_test.go
@@ -1,8 +1,6 @@
 package str
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/data/coerce"
@@ -21,7 +19,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(Equal(errors.New("unable to interpret $() to string; error was unable to interpret '' as reference; '' not in scope")))
+			Expect(actualErr).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 	Context("value.Interpret doesn't err", func() {

--- a/sdks/go/opspec/interpreter/value/interpret.go
+++ b/sdks/go/opspec/interpreter/value/interpret.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/interpolater"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
+	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a value
@@ -44,21 +45,21 @@ func Interpret(
 				scope,
 			)
 			if nil != err {
-				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property; error was %v", propertyKeyExpression, propertyValueExpression, err)
+				return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v: %v' as object initializer property", propertyKeyExpression, propertyValueExpression))
 			}
 
 			if nil != propertyValue.File {
 				fileBytes, err := ioutil.ReadFile(*propertyValue.File)
 				if nil != err {
-					return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property; error was %v", propertyKeyExpression, propertyValueExpression, err)
+					return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v: %v' as object initializer property", propertyKeyExpression, propertyValueExpression))
 				}
 
 				value[propertyKey] = string(fileBytes)
 				continue
 			} else if nil != propertyValue.Dir {
-				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property; directories aren't valid object properties", propertyKeyExpression, propertyValueExpression)
+				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property: directories aren't valid object properties", propertyKeyExpression, propertyValueExpression)
 			} else if nil != propertyValue.Socket {
-				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property; sockets aren't valid object properties", propertyKeyExpression, propertyValueExpression)
+				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property: sockets aren't valid object properties", propertyKeyExpression, propertyValueExpression)
 			}
 
 			unboxedPropertyValue, unboxErr := propertyValue.Unbox()
@@ -79,7 +80,7 @@ func Interpret(
 				scope,
 			)
 			if nil != err {
-				return model.Value{}, fmt.Errorf("unable to interpret '%+v' as array initializer item; error was %v", itemExpression, err)
+				return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%+v' as array initializer item", itemExpression))
 			}
 			value = append(value, itemValue)
 		}
@@ -112,6 +113,6 @@ func Interpret(
 	case model.Value:
 		return typedValueExpression, nil
 	default:
-		return model.Value{}, fmt.Errorf("unable to interpret %+v as value; unsupported type", typedValueExpression)
+		return model.Value{}, fmt.Errorf("unable to interpret %+v as value: unsupported type", typedValueExpression)
 	}
 }

--- a/sdks/go/opspec/interpreter/value/interpret_test.go
+++ b/sdks/go/opspec/interpreter/value/interpret_test.go
@@ -1,8 +1,6 @@
 package value
 
 import (
-	"errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -70,7 +68,7 @@ var _ = Context("Interpret", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(errors.New("unable to interpret '' as reference; '' not in scope")))
+				Expect(actualErr).To(MatchError("unable to interpret '' as reference: '' not in scope"))
 
 			})
 		})

--- a/sdks/go/opspec/list.go
+++ b/sdks/go/opspec/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
+	"github.com/pkg/errors"
 )
 
 // List ops recursively within a directory, returning discovered op files by path.
@@ -27,20 +28,20 @@ func List(
 
 			opFileReader, err := dirHandle.GetContent(ctx, content.Path)
 			if nil != err {
-				return nil, fmt.Errorf("error opening %s%s; %s", dirHandle.Ref(), content.Path, err)
+				return nil, errors.Wrap(err, fmt.Sprintf("error opening %s%s", dirHandle.Ref(), content.Path))
 			}
 
 			opFileBytes, err := ioutil.ReadAll(opFileReader)
 			opFileReader.Close()
 			if nil != err {
-				return nil, fmt.Errorf("error reading %s%s; %s", dirHandle.Ref(), content.Path, err)
+				return nil, errors.Wrap(err, fmt.Sprintf("error reading %s%s", dirHandle.Ref(), content.Path))
 			}
 
 			opFile, err := opfile.Unmarshal(
 				opFileBytes,
 			)
 			if nil != err {
-				return nil, fmt.Errorf("error unmarshalling %s%s; %s", dirHandle.Ref(), content.Path, err)
+				return nil, errors.Wrap(err, fmt.Sprintf("error unmarshalling %s%s", dirHandle.Ref(), content.Path))
 			}
 
 			opsByPath[filepath.Dir(content.Path)] = opFile

--- a/sdks/go/opspec/list_test.go
+++ b/sdks/go/opspec/list_test.go
@@ -102,7 +102,7 @@ var _ = Context("List", func() {
 						/* assert */
 						Expect(actualOpYmls).To(BeEmpty())
 						Expect(actualErr).
-							To(Equal(fmt.Errorf("error opening %s%s; %s", expectedRef, expectedPath, getContentErr)))
+							To(MatchError(fmt.Sprintf("error opening %s%s: %s", expectedRef, expectedPath, getContentErr)))
 					})
 				})
 			})

--- a/sdks/go/opspec/opfile/unmarshal_test.go
+++ b/sdks/go/opspec/opfile/unmarshal_test.go
@@ -1,8 +1,6 @@
 package opfile
 
 import (
-	"errors"
-
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -17,7 +15,7 @@ var _ = Context("Unmarshal", func() {
 			_, actualError := Unmarshal([]byte("&"))
 
 			/* assert */
-			Expect(actualError).To(Equal(errors.New("\n-\n  Error(s):\n    - error converting YAML to JSON: yaml: did not find expected alphabetic or numeric character\n-")))
+			Expect(actualError).To(MatchError("\n-\n  Error(s):\n    - error converting YAML to JSON: yaml: did not find expected alphabetic or numeric character\n-"))
 		})
 	})
 	Context("Validator.Validate doesn't return errors", func() {

--- a/sdks/go/opspec/validate_test.go
+++ b/sdks/go/opspec/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 var _ = Context("Validate", func() {
@@ -36,7 +37,7 @@ var _ = Context("Validate", func() {
 
 							description := fmt.Sprintf("scenario '%v'", path)
 							if err := yaml.Unmarshal(scenariosOpFileBytes, &scenarioOpFile); nil != err {
-								panic(fmt.Errorf("error unmarshalling %v; error was %v", description, err))
+								panic(errors.Wrap(err, "error unmarshalling "+description))
 							}
 
 							for _, scenario := range scenarioOpFile {


### PR DESCRIPTION
This cleans up error wrapping in the codebase to use the more modern `errors.Wrap` pattern (`"%w"`). The long term benefit of this is to allow deep checking of error types, but it also sets better conformance with idiomatic go standards.

More reading:
- https://blog.golang.org/go1.13-errors
- https://golang.org/doc/effective_go#errors
- https://staticcheck.io/docs/checks#ST1005