### PR TITLE
Detect invalid outputs in opspecs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,7 @@
             "host": "127.0.0.1"
         },
         {
-            "name": "Run and debug a test file",
+            "name": "Run and debug this test suite",
             "type": "go",
             "request": "launch",
             "mode": "test",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,21 @@ accordance with
 
 ## [Unreleased]
 
-## 0.1.48 - 2021-02-28
-
 ### Added
 
-- API client now embeds local files/dirs as objects enabling starting ops w/ file/dir inputs on remote nodes.
+- Basic support for sending local files and directories to remote nodes when using the API client
 
 ### Changed
 
 - Self-update now uses github releases instead of equinox.io
 - API now limits request body to 40Mb
+- Improved error output when op resolution fails. You'll now see a list of resolutions tried and why each failed. (https://github.com/opctl/opctl/pull/883)
+- More consistent error messaging formats (https://github.com/opctl/opctl/pull/885)
+- Detect invalid op output names (https://github.com/opctl/opctl/issues/798)
 
 ### Removed
 
-- Windows build; use linux build via WSL 2 instead.
+- Windows build; use linux build via WSL 2 instead
 
 ## 0.1.47 - 2021-01-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,24 @@ First, ensure dependencies are installed
 - [gpgme](https://www.gnupg.org/related_software/gpgme/) (on macOS, `brew install gpgme`)
 - [dlv](https://github.com/go-delve/delve) (for debugging) - Because this project uses go modules, install this globally with `go get github.com/go-delve/delve` to run the tool outside of the project directory.
 
+## CLI debugging
+
 Build a binary with
 
 `go build -o opctl-beta ./cli`
 
-To debug
+Run with [dlv](https://github.com/go-delve/delve), e.g.
 
 `go run github.com/go-delve/delve/cmd/dlv --check-go-version=false --listen=127.0.0.1:40000 --headless=true --api-version=2 exec /PATH/TO/OPCTL/opctl-beta run dev`
 
-This will suspend execution until a client connects on port 40000. If using VSCode, you can use the saved run configuration to connect.
+This will suspend execution until a client connects on port 40000. If using VSCode, you can use the "Connect to dlv debugger" run configuration to connect.
 
 On macOS, you can debug exit signal handling by sending an interrupt to the underlying PID. When the debugger connects, it will give you the with a message like: `Got a connection, launched process ../opctl/opctl-beta (pid = 79924).` (path to process and PID will be different). Kill with `kill -SIGINT 72958`.
+
+## Node debugging
+
+Ops are run in a "node" running as an external process, which means debugging the CLI directly doesn't catch most of the logic. To debug this external process, run `opctl node kill` to kill the current node (attached to port 42224), then use the VSCode "Run and debug an opctl node" run configuration to spin up a new node with the debugger attached or debug the CLI command "opctl node create".
+
+## Tests
+
+This project uses the [Ginkgo](https://github.com/onsi/ginkgo) test framework, which means some IDE's go tooling won't support normal methods of running tests. Run the VSCode "Run and debug this test suite" run configuration while viewing a test file to run the tests attached to the debugger.

--- a/cli/events.go
+++ b/cli/events.go
@@ -36,5 +36,4 @@ func events(
 
 		cliOutput.Event(&event)
 	}
-	return nil
 }

--- a/sdks/go/node/core/containerCaller.go
+++ b/sdks/go/node/core/containerCaller.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/node/core/containerruntime"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/pubsub"
 )
 
@@ -201,7 +201,7 @@ func (this _containerCaller) interpretOutputs(
 			if callSpecContainerFilePath == callContainerFilePath {
 				// copy callHostFilePath before taking address; range vars have same address for every iteration
 				value := callHostFilePath
-				outputs[strings.TrimSuffix(strings.TrimPrefix(mountSrcStr, "$("), ")")] = &model.Value{File: &value}
+				outputs[opspec.RefToName(mountSrcStr)] = &model.Value{File: &value}
 			}
 		}
 	}
@@ -221,7 +221,7 @@ func (this _containerCaller) interpretOutputs(
 			if callSpecContainerDirPath == callContainerDirPath {
 				// copy callHostDirPath before taking address; range vars have same address for every iteration
 				value := callHostDirPath
-				outputs[strings.TrimSuffix(strings.TrimPrefix(mountSrcStr, "$("), ")")] = &model.Value{Dir: &value}
+				outputs[opspec.RefToName(mountSrcStr)] = &model.Value{Dir: &value}
 			}
 		}
 	}

--- a/sdks/go/node/core/opCaller.go
+++ b/sdks/go/node/core/opCaller.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/outputs"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
 )
@@ -100,6 +100,7 @@ func (oc _opCaller) Call(
 	opOutputs, err = outputs.Interpret(
 		opOutputs,
 		opFile.Outputs,
+		opCallSpec.Outputs,
 		opCall.OpPath,
 		filepath.Join(oc.callScratchDir, opCall.OpID),
 	)
@@ -116,7 +117,7 @@ func (oc _opCaller) Call(
 			boundName = boundValue
 			boundValue = prevBoundName
 		} else {
-			boundValue = strings.TrimSuffix(strings.TrimPrefix(boundValue, "$("), ")")
+			boundValue = opspec.RefToName(boundValue)
 		}
 		for opOutputName, opOutputValue := range opOutputs {
 			if boundName == opOutputName {

--- a/sdks/go/node/core/parallelCaller.go
+++ b/sdks/go/node/core/parallelCaller.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
-	"strings"
 	"time"
 
 	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/pubsub"
 )
 
@@ -41,10 +41,6 @@ func newParallelCaller(
 
 }
 
-func refToName(ref string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(ref, "$("), ")")
-}
-
 type _parallelCaller struct {
 	caller caller
 	pubSub pubsub.PubSub
@@ -69,7 +65,7 @@ func (pc _parallelCaller) Call(
 	for _, callSpecChildCall := range callSpecParallelCall {
 		// increment needed by counts for any needs
 		for _, neededCallRef := range callSpecChildCall.Needs {
-			childCallNeededCountByName[refToName(neededCallRef)]++
+			childCallNeededCountByName[opspec.RefToName(neededCallRef)]++
 		}
 	}
 
@@ -145,7 +141,7 @@ eventLoop:
 
 				// decrement needed by counts for any needs
 				for _, neededCallRef := range callSpecParallelCall[childCallIndex].Needs {
-					childCallNeededCountByName[refToName(neededCallRef)]--
+					childCallNeededCountByName[opspec.RefToName(neededCallRef)]--
 				}
 
 				for neededCallName, neededCount := range childCallNeededCountByName {

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang-utils/dircopier"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/pkg/errors"
 )
@@ -24,7 +25,7 @@ dirLoop:
 
 		if nil == dirExpression {
 			// bound implicitly
-			dirExpression = fmt.Sprintf("$(%v)", callSpecContainerDirPath)
+			dirExpression = opspec.NameToRef(callSpecContainerDirPath)
 		}
 
 		dirValue, err := dir.Interpret(
@@ -35,7 +36,7 @@ dirLoop:
 		)
 		if nil != err {
 			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind %v to %v",
+				"unable to bind directory %v to %v",
 				callSpecContainerDirPath,
 				dirExpression,
 			))

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret_test.go
@@ -35,7 +35,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(MatchError("unable to bind /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
+			Expect(actualErr).To(MatchError("unable to bind directory /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
 		})
 	})
 	Context("dir.Interpret doesn't err", func() {

--- a/sdks/go/opspec/interpreter/call/container/files/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/files/interpret.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang-utils/filecopier"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/file"
 	"github.com/pkg/errors"
 )
@@ -26,7 +27,7 @@ fileLoop:
 
 		if nil == fileExpression {
 			// bound implicitly
-			fileExpression = fmt.Sprintf("$(%v)", callSpecContainerFilePath)
+			fileExpression = opspec.NameToRef(callSpecContainerFilePath)
 		}
 
 		fileValue, err := file.Interpret(
@@ -37,7 +38,7 @@ fileLoop:
 		)
 		if nil != err {
 			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind %v to %v",
+				"unable to bind file %v to %v",
 				callSpecContainerFilePath,
 				fileExpression,
 			))

--- a/sdks/go/opspec/interpreter/call/container/files/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/files/interpret_test.go
@@ -23,7 +23,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{
-					identifier: &model.Value{Socket: new(string)},
+					identifier: {Socket: new(string)},
 				},
 				providedContainerCallSpecFiles,
 				"dummyScratchDirPath",
@@ -31,7 +31,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(MatchError("unable to bind /somewhere to $(identifier): unable to coerce '{\"socket\":\"\"}' to file"))
+			Expect(actualErr).To(MatchError("unable to bind file /somewhere to $(identifier): unable to coerce '{\"socket\":\"\"}' to file"))
 		})
 	})
 	Context("value.File not prefixed by dataDirPath", func() {
@@ -39,7 +39,7 @@ var _ = Context("Interpret", func() {
 			/* arrange */
 			identifier := "identifier"
 			providedScope := map[string]*model.Value{
-				identifier: &model.Value{File: new(string)},
+				identifier: {File: new(string)},
 			}
 
 			containerPath := "/somewhere"
@@ -92,7 +92,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			actualResult, actualErr := Interpret(
 				map[string]*model.Value{
-					identifier: &model.Value{
+					identifier: {
 						File: &referencedFilePath,
 					},
 				},

--- a/sdks/go/opspec/interpreter/call/container/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret_test.go
@@ -51,7 +51,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{
-					identifier: &model.Value{
+					identifier: {
 						Socket: new(string),
 					},
 				},
@@ -69,7 +69,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(MatchError("unable to bind /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
+			Expect(actualErr).To(MatchError("unable to bind directory /something to $(identifier): unable to interpret $(identifier) to dir: unable to coerce socket to dir: incompatible types"))
 		})
 	})
 
@@ -111,7 +111,7 @@ var _ = Context("Interpret", func() {
 			/* act */
 			_, actualErr := Interpret(
 				map[string]*model.Value{
-					"not": &model.Value{
+					"not": {
 						Socket: new(string),
 					},
 				},
@@ -129,7 +129,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(MatchError("unable to bind /something to $(not): unable to coerce '{\"socket\":\"\"}' to file"))
+			Expect(actualErr).To(MatchError("unable to bind file /something to $(not): unable to coerce '{\"socket\":\"\"}' to file"))
 		})
 	})
 

--- a/sdks/go/opspec/interpreter/call/loop/iteration/scope.go
+++ b/sdks/go/opspec/interpreter/call/loop/iteration/scope.go
@@ -2,16 +2,12 @@ package iteration
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/loopable"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
 )
-
-func refToVariable(ref *string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(*ref, "$("), ")")
-}
 
 func sortMap(
 	m map[string]interface{},
@@ -47,7 +43,7 @@ func Scope(
 	if nil != loopVarsSpec.Index {
 		// assign iteration index to requested inboundScope variable
 		indexAsFloat64 := float64(index)
-		outboundScope[refToVariable(loopVarsSpec.Index)] = &model.Value{
+		outboundScope[opspec.RefToName(*loopVarsSpec.Index)] = &model.Value{
 			Number: &indexAsFloat64,
 		}
 	}
@@ -90,7 +86,7 @@ func Scope(
 
 		if nil != loopVarsSpec.Key {
 			// only add key to scope if declared
-			outboundScope[refToVariable(loopVarsSpec.Key)] = &model.Value{String: &name}
+			outboundScope[opspec.RefToName(*loopVarsSpec.Key)] = &model.Value{String: &name}
 		}
 	}
 
@@ -104,7 +100,7 @@ func Scope(
 			return nil, err
 		}
 
-		outboundScope[refToVariable(loopVarsSpec.Value)] = &v
+		outboundScope[opspec.RefToName(*loopVarsSpec.Value)] = &v
 	}
 
 	return outboundScope, nil

--- a/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/array"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/boolean"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
@@ -34,7 +35,7 @@ func Interpret(
 		if !ok {
 			return nil, fmt.Errorf("unable to bind to '%v' via implicit ref: '%v' not in scope", name, name)
 		}
-		valueExpression = fmt.Sprintf("$(%v)", name)
+		valueExpression = opspec.NameToRef(name)
 	}
 
 	switch {

--- a/sdks/go/opspec/interpreter/call/op/outputs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/outputs/interpret.go
@@ -1,7 +1,12 @@
 package outputs
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params"
 )
 
@@ -9,20 +14,60 @@ import (
 func Interpret(
 	outputArgs map[string]*model.Value,
 	outputParams map[string]*model.Param,
+	callOutputs map[string]string,
 	opPath string,
 	opScratchDir string,
 ) (
 	map[string]*model.Value,
 	error,
 ) {
-
 	outputArgs, err := params.Coerce(outputArgs, outputParams, opScratchDir)
-	if nil != err {
+	if err != nil {
 		return outputArgs, err
 	}
 
 	argsWithDefaults := params.ApplyDefaults(outputArgs, outputParams, opPath)
 
-	return argsWithDefaults, params.Validate(argsWithDefaults, outputParams)
+	// ensure the called op supplies each output the callee is expecting
+	for callOutputParamName, callOutputParamBoundName := range callOutputs {
+		if _, ok := outputParams[callOutputParamName]; !ok {
+			// maybe the user has flipped the key and value?
+			if _, ok := outputParams[opspec.RefToName(callOutputParamBoundName)]; ok {
+				return nil, fmt.Errorf(
+					"unknown output '%s', did you mean to use `%s: %s`?",
+					callOutputParamName,
+					opspec.RefToName(callOutputParamBoundName),
+					opspec.NameToRef(callOutputParamName),
+				)
+			}
 
+			// try to figure out what the user should have provided
+			var missingCallOutputParams []string
+			for name := range outputParams {
+				if _, ok := callOutputs[name]; !ok {
+					missingCallOutputParams = append(missingCallOutputParams, name)
+				}
+			}
+			// different environments have different ordering behaviors
+			sort.Strings(missingCallOutputParams)
+
+			if len(missingCallOutputParams) == 1 {
+				return nil, fmt.Errorf(
+					"unknown output '%s', expected '%s'",
+					callOutputParamName,
+					missingCallOutputParams[0],
+				)
+			} else if len(missingCallOutputParams) > 0 {
+				return nil, fmt.Errorf(
+					"unknown output '%s', expected one of [%s]",
+					callOutputParamName,
+					strings.Join(missingCallOutputParams, ", "),
+				)
+			} else {
+				return nil, fmt.Errorf("unknown output '%s'", callOutputParamName)
+			}
+		}
+	}
+
+	return argsWithDefaults, params.Validate(argsWithDefaults, outputParams)
 }

--- a/sdks/go/opspec/interpreter/call/op/outputs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/op/outputs/interpret_test.go
@@ -14,14 +14,14 @@ var _ = Context("Interpret", func() {
 		stringParamName := "stringParamName"
 
 		providedArgs := map[string]*model.Value{
-			stringParamName: &model.Value{Array: &arrayValue},
+			stringParamName: {Array: &arrayValue},
 		}
 
 		providedParams := map[string]*model.Param{
-			stringParamName: &model.Param{
-				String: &model.StringParam{},
-			},
+			stringParamName: {String: &model.StringParam{}},
 		}
+
+		providedOpCallOutputs := map[string]string{}
 
 		arrayValueAsString, err := coerce.ToString(providedArgs[stringParamName])
 		if nil != err {
@@ -36,6 +36,7 @@ var _ = Context("Interpret", func() {
 		actualOutputs, actualErr := Interpret(
 			providedArgs,
 			providedParams,
+			providedOpCallOutputs,
 			"opPath",
 			"opScratchDir",
 		)
@@ -43,6 +44,122 @@ var _ = Context("Interpret", func() {
 		/* assert */
 		Expect(actualOutputs).To(Equal(expectedOutputs))
 		Expect(actualErr).To(BeNil())
+	})
+	Describe("ensures expected outputs match actual outputs", func() {
+		It("detects inverted naming", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{
+					"bar": {String: &model.StringParam{}},
+				},
+				map[string]string{
+					"foo": "$(bar)",
+				},
+				"opPath",
+				"opScratchDir",
+			)
 
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'foo', did you mean to use `bar: $(foo)`?"))
+		})
+		It("indicates what was expected when one output exists", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{
+					"bar": {String: &model.StringParam{}},
+				},
+				map[string]string{
+					"foo": "",
+				},
+				"opPath",
+				"opScratchDir",
+			)
+
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'foo', expected 'bar'"))
+		})
+		It("indicates what was expected when one remaining output exists", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{
+					"x": {String: &model.StringParam{}},
+					"y": {String: &model.StringParam{}},
+					"z": {String: &model.StringParam{}},
+				},
+				map[string]string{
+					"x": "",
+					"y": "",
+					"a": "",
+				},
+				"opPath",
+				"opScratchDir",
+			)
+
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'a', expected 'z'"))
+		})
+		It("indicates what was expected when multiple outputs exist", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{
+					"x": {String: &model.StringParam{}},
+					"y": {String: &model.StringParam{}},
+					"z": {String: &model.StringParam{}},
+				},
+				map[string]string{
+					"a": "",
+				},
+				"opPath",
+				"opScratchDir",
+			)
+
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'a', expected one of [x, y, z]"))
+		})
+		It("indicates what was expected when multiple remaining outputs exist", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{
+					"x": {String: &model.StringParam{}},
+					"y": {String: &model.StringParam{}},
+					"z": {String: &model.StringParam{}},
+				},
+				map[string]string{
+					"x": "",
+					"a": "",
+				},
+				"opPath",
+				"opScratchDir",
+			)
+
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'a', expected one of [y, z]"))
+		})
+		It("provides information when it doesn't know what was expected", func() {
+			/* act */
+			actualOutputs, actualErr := Interpret(
+				map[string]*model.Value{},
+				map[string]*model.Param{},
+				map[string]string{
+					"a": "",
+				},
+				"opPath",
+				"opScratchDir",
+			)
+
+			/* assert */
+			Expect(actualOutputs).To(BeNil())
+			Expect(actualErr).To(MatchError("unknown output 'a'"))
+		})
 	})
 })

--- a/sdks/go/opspec/interpreter/interpolater/interpolate.go
+++ b/sdks/go/opspec/interpreter/interpolater/interpolate.go
@@ -1,9 +1,9 @@
 package interpolater
 
 import (
-	"fmt"
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 )
 
@@ -85,7 +85,7 @@ func tryDeRef(
 		switch possibleRef[i] {
 		case refCloser:
 			if len(refBuffer) > 0 && refOpener == refBuffer[0] {
-				value, err := reference.Interpret(fmt.Sprintf("$(%v)", string(refBuffer[1:])), scope, nil)
+				value, err := reference.Interpret(opspec.NameToRef(string(refBuffer[1:])), scope, nil)
 				if nil != err {
 					return "", 0, err
 				}

--- a/sdks/go/opspec/interpreter/value/interpret.go
+++ b/sdks/go/opspec/interpreter/value/interpret.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/interpolater"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 	"github.com/pkg/errors"
@@ -38,7 +39,7 @@ func Interpret(
 
 			if nil == propertyValueExpression {
 				// implicit reference
-				propertyValueExpression = fmt.Sprintf("$(%v)", propertyKeyExpression)
+				propertyValueExpression = opspec.NameToRef(propertyKeyExpression)
 			}
 			propertyValue, err := Interpret(
 				propertyValueExpression,

--- a/sdks/go/opspec/ref.go
+++ b/sdks/go/opspec/ref.go
@@ -1,0 +1,16 @@
+package opspec
+
+import (
+	"fmt"
+	"strings"
+)
+
+// RefToName converts a variable reference to the name of the variable
+func RefToName(ref string) string {
+	return strings.TrimSuffix(strings.TrimPrefix(ref, "$("), ")")
+}
+
+// NameToRef converts a variable name to the reference form in an opspec
+func NameToRef(name string) string {
+	return fmt.Sprintf("$(%s)", name)
+}

--- a/sdks/go/opspec/ref_test.go
+++ b/sdks/go/opspec/ref_test.go
@@ -1,0 +1,19 @@
+package opspec
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestRefToName(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(RefToName("$(foo)")).To(Equal("foo"))
+}
+
+func TestNameToRef(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	g.Expect(NameToRef("foo")).To(Equal("$(foo)"))
+}


### PR DESCRIPTION
This introduces validation of outputs when making op calls. Currently, if an invalid output is used, it's ignored. When used later in an op, it's easy to misinterpret the errors produced as happening in the wrong place.

I made an attempt to try to detect common user-errors and proactively provide information to help solve the error (see test cases).

I also consolidated the scattered logic for converting a variable reference to its name (`$(foo)` to `foo`) into a single, unit tested, utility function.

This is technically backwards incompatible - currently if an invalid op output is specified and never used, it will be silently ignored. This changes so it will now cause an error, as it's not a valid reference. Resolving is as simple as removing the bad output line, so I think this is definitely worth the increased usability, given the v0 status of opctl.

Resolves https://github.com/opctl/opctl/issues/798