### PR TITLE
Fix syntax error in the cli compilation opspec

### DIFF
--- a/cli/.opspec/compile/op.yml
+++ b/cli/.opspec/compile/op.yml
@@ -15,7 +15,7 @@ run:
       - darwin
       - linux
     vars:
-      value: $(GOOS)
+      value: GOOS
     run:
       container:
         cmd:


### PR DESCRIPTION
Although it works somehow, there's currently a schema violation in the cli compilation opspec that I notice whenever I touch it.

![op yml — opctl - Code - 2021-03-19 at 17 07 06](https://user-images.githubusercontent.com/329222/111809687-8a061c80-88d5-11eb-97a5-15a300151dbd.png)
