### PR TITLE
Update format of links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ accordance with
 
 - Self-update now uses github releases instead of equinox.io
 - API now limits request body to 40Mb
-- Improved error output when op resolution fails. You'll now see a list of resolutions tried and why each failed. (https://github.com/opctl/opctl/pull/883)
-- More consistent error messaging formats (https://github.com/opctl/opctl/pull/885)
-- Detect invalid op output names (https://github.com/opctl/opctl/issues/798)
+- [Improved error output when op resolution fails. You'll now see a list of resolutions tried and why each failed.](https://github.com/opctl/opctl/pull/883)
+- [More consistent error messaging formats](https://github.com/opctl/opctl/pull/885)
+- [Detect invalid op output names](https://github.com/opctl/opctl/issues/798)
 
 ### Removed
 


### PR DESCRIPTION
I didn't notice this pattern until after merging https://github.com/opctl/opctl/pull/893