### PR TITLE
Skip pulling tagged, non-latest, already pulled images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ accordance with
 - [More consistent error messaging formats](https://github.com/opctl/opctl/pull/885)
 - [Detect invalid op output names](https://github.com/opctl/opctl/issues/798)
 - [Deprecated param.<datatype>.description; use param.description](https://github.com/opctl/opctl/issues/898)
+- [Docker images will only be pulled if using the `latest` tag (or untagged) or have not been pulled previously](https://github.com/opctl/opctl/issues/920)
 
 ### Fixed
 

--- a/sdks/go/node/core/containerruntime/docker/imagePuller.go
+++ b/sdks/go/node/core/containerruntime/docker/imagePuller.go
@@ -3,8 +3,12 @@ package docker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"strings"
+	"time"
 
+	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -16,9 +20,7 @@ import (
 type imagePuller interface {
 	Pull(
 		ctx context.Context,
-		containerID string,
-		imagePullCreds *model.Creds,
-		imageRef string,
+		containerCall *model.ContainerCall,
 		rootCallID string,
 		eventPublisher pubsub.EventPublisher,
 	) error
@@ -38,12 +40,41 @@ type _imagePuller struct {
 
 func (ip _imagePuller) Pull(
 	ctx context.Context,
-	containerID string,
-	imagePullCreds *model.Creds,
-	imageRef string,
+	containerCall *model.ContainerCall,
 	rootCallID string,
 	eventPublisher pubsub.EventPublisher,
 ) error {
+	imageRef := *containerCall.Image.Ref
+	imagePullCreds := containerCall.Image.PullCreds
+	containerID := containerCall.ContainerID
+
+	// Skip pulling for non-tagged images that already are present
+	// This reduces the chance of hitting docker rate limiting errors
+	// and speeds up execution.
+	ref, err := reference.ParseAnyReference(strings.ToLower(imageRef))
+	if err != nil {
+		return err
+	}
+	named, err := reference.ParseNormalizedNamed(ref.String())
+	if err != nil {
+		return err
+	}
+	if tagged, ok := named.(reference.Tagged); ok && tagged.Tag() != "latest" {
+		_, _, err := ip.dockerClient.ImageInspectWithRaw(ctx, imageRef)
+		if err == nil {
+			eventPublisher.Publish(model.Event{
+				Timestamp: time.Now().UTC(),
+				ContainerStdOutWrittenTo: &model.ContainerStdOutWrittenTo{
+					Data:        []byte(fmt.Sprintf("Skipping image pull: %s\n", imageRef)),
+					OpRef:       containerCall.OpPath,
+					ContainerID: containerCall.ContainerID,
+					RootCallID:  rootCallID,
+				},
+			})
+
+			return nil
+		}
+	}
 
 	imagePullOptions := types.ImagePullOptions{}
 	if imagePullCreds != nil &&

--- a/sdks/go/node/core/containerruntime/docker/imagePuller_test.go
+++ b/sdks/go/node/core/containerruntime/docker/imagePuller_test.go
@@ -58,11 +58,48 @@ var _ = Context("imagePuller", func() {
 			/* arrange */
 			providedImageRef := "imageRef:myversion"
 			providedCtx := context.Background()
+			dockerClient := new(FakeCommonAPIClient)
+
+			objectUnderTest := _imagePuller{
+				dockerClient: dockerClient,
+			}
+
+			/* act */
+			err := objectUnderTest.Pull(
+				providedCtx,
+				&model.ContainerCall{
+					ContainerID: "",
+					Image: &model.ContainerCallImage{
+						PullCreds: &model.Creds{},
+						Ref:       &providedImageRef,
+					},
+				},
+				"",
+				new(FakeEventPublisher),
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			/* assert */
+			// Checked if image exists
+			ctx, inspectedImageRef := dockerClient.ImageInspectWithRawArgsForCall(0)
+			Expect(ctx).To(Equal(providedCtx))
+			Expect(inspectedImageRef).To(Equal(providedImageRef))
+			// Didn't pull
+			Expect(dockerClient.ImagePullCallCount()).To(Equal(0))
+		})
+		It("should pul when image is not present and ref is tagged non-latest", func() {
+			/* arrange */
+			providedImageRef := "imageRef:myversion"
+			expectedImagePullOptions := types.ImagePullOptions{}
+			providedCtx := context.Background()
 
 			imagePullResponse := ioutil.NopCloser(bytes.NewBufferString(""))
 
 			_fakeDockerClient := new(FakeCommonAPIClient)
 			_fakeDockerClient.ImagePullReturns(imagePullResponse, nil)
+			_fakeDockerClient.ImageInspectWithRawReturns(types.ImageInspect{}, nil, errors.New("not found"))
 
 			objectUnderTest := _imagePuller{
 				dockerClient: _fakeDockerClient,
@@ -90,8 +127,11 @@ var _ = Context("imagePuller", func() {
 			ctx, inspectedImageRef := _fakeDockerClient.ImageInspectWithRawArgsForCall(0)
 			Expect(ctx).To(Equal(providedCtx))
 			Expect(inspectedImageRef).To(Equal(providedImageRef))
-			// Didn't pull
-			Expect(_fakeDockerClient.ImagePullCallCount()).To(Equal(0))
+			// Pulled
+			actualCtx, actualImageRef, actualImagePullOptions := _fakeDockerClient.ImagePullArgsForCall(0)
+			Expect(actualCtx).To(Equal(providedCtx))
+			Expect(actualImageRef).To(Equal(providedImageRef))
+			Expect(actualImagePullOptions).To(Equal(expectedImagePullOptions))
 		})
 		Context("dockerClient.ImagePull errors", func() {
 			It("should return expected error", func() {

--- a/sdks/go/node/core/containerruntime/docker/internal/fakes/imagePuller.go
+++ b/sdks/go/node/core/containerruntime/docker/internal/fakes/imagePuller.go
@@ -10,15 +10,13 @@ import (
 )
 
 type FakeImagePuller struct {
-	PullStub        func(context.Context, string, *model.Creds, string, string, pubsub.EventPublisher) error
+	PullStub        func(context.Context, *model.ContainerCall, string, pubsub.EventPublisher) error
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 context.Context
-		arg2 string
-		arg3 *model.Creds
-		arg4 string
-		arg5 string
-		arg6 pubsub.EventPublisher
+		arg2 *model.ContainerCall
+		arg3 string
+		arg4 pubsub.EventPublisher
 	}
 	pullReturns struct {
 		result1 error
@@ -30,21 +28,19 @@ type FakeImagePuller struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImagePuller) Pull(arg1 context.Context, arg2 string, arg3 *model.Creds, arg4 string, arg5 string, arg6 pubsub.EventPublisher) error {
+func (fake *FakeImagePuller) Pull(arg1 context.Context, arg2 *model.ContainerCall, arg3 string, arg4 pubsub.EventPublisher) error {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
 		arg1 context.Context
-		arg2 string
-		arg3 *model.Creds
-		arg4 string
-		arg5 string
-		arg6 pubsub.EventPublisher
-	}{arg1, arg2, arg3, arg4, arg5, arg6})
-	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
+		arg2 *model.ContainerCall
+		arg3 string
+		arg4 pubsub.EventPublisher
+	}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3, arg4})
 	fake.pullMutex.Unlock()
 	if fake.PullStub != nil {
-		return fake.PullStub(arg1, arg2, arg3, arg4, arg5, arg6)
+		return fake.PullStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -59,17 +55,17 @@ func (fake *FakeImagePuller) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImagePuller) PullCalls(stub func(context.Context, string, *model.Creds, string, string, pubsub.EventPublisher) error) {
+func (fake *FakeImagePuller) PullCalls(stub func(context.Context, *model.ContainerCall, string, pubsub.EventPublisher) error) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImagePuller) PullArgsForCall(i int) (context.Context, string, *model.Creds, string, string, pubsub.EventPublisher) {
+func (fake *FakeImagePuller) PullArgsForCall(i int) (context.Context, *model.ContainerCall, string, pubsub.EventPublisher) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeImagePuller) PullReturns(result1 error) {

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -104,13 +104,9 @@ func (cr _runContainer) RunContainer(
 			req.Image.Src,
 		)
 	} else {
-		// always pull latest version of image
-		// note: this trades local reproducibility for distributed reproducibility
 		imageErr = cr.imagePuller.Pull(
 			ctx,
-			req.ContainerID,
-			req.Image.PullCreds,
-			*req.Image.Ref,
+			req,
 			rootCallID,
 			eventPublisher,
 		)

--- a/sdks/go/node/core/containerruntime/docker/runContainer_test.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer_test.go
@@ -196,16 +196,12 @@ var _ = Context("RunContainer", func() {
 
 			/* assert */
 			actualCtx,
-				actualContainerID,
-				actualImagePullCreds,
-				actualImageRef,
+				actualReq,
 				actualRootCallID,
 				actualEventPublisher := fakeImagePuller.PullArgsForCall(0)
 
 			Expect(actualCtx).To(Equal(providedCtx))
-			Expect(actualContainerID).To(Equal(providedReq.ContainerID))
-			Expect(actualImagePullCreds).To(Equal(providedReq.Image.PullCreds))
-			Expect(actualImageRef).To(Equal(*providedReq.Image.Ref))
+			Expect(actualReq).To(Equal(providedReq))
 			Expect(actualRootCallID).To(Equal(providedRootCallID))
 			Expect(actualEventPublisher).To(Equal(providedEventPublisher))
 		})


### PR DESCRIPTION
The goal here is to help avoid rate limiting errors we've been seeing frequently in CI builds, which are causing significant friction. Given CI nodes are swapped out regularly and we'll still always pull tagged or latest tagged images, this should be pretty resilient.

Resolves #920, INFRA-1870