### PR TITLE
add example to string parameter

### DIFF
--- a/website/docs/reference/opspec/op-directory/op/parameter/string.md
+++ b/website/docs/reference/opspec/op-directory/op/parameter/string.md
@@ -23,3 +23,32 @@ A [markdown [string]](../markdown.md) defining a human friendly description of t
 
 #### isSecret
 A boolean indicating if the value of the parameter is secret. This will cause it to be hidden in UI's for example.
+
+## Example
+
+This is an example op that uses a string input, with a default value
+
+```yaml
+name: example
+description: an example op
+inputs:
+  example-input:
+    string:
+      default: "a default value"
+run:
+  container:
+    image: { ref: 'alpine' }
+    cmd: ['echo', $(example-input)]
+```
+
+Using the example op:
+```shell-script
+opctl run example
+```
+The expected output is the op running and echoing "a default value".
+
+Using the example op while overriding the default value:
+```shell-script
+opctl run -a example-input="hello world" example
+```
+The expected output is the op running and echoing "hello world".


### PR DESCRIPTION
I added an example to a string parameter.  Originally this [PR](https://github.com/opctl/opctl/pull/918), but since I haven't cloned the project it's easier for me to make a new pr in the right file than it is to fix the old pr.