### PR TITLE
change edit url from `master` to `main`

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -74,7 +74,7 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          editUrl: "https://github.com/opctl/opctl/edit/master/website/",
+          editUrl: "https://github.com/opctl/opctl/edit/main/website/",
           sidebarPath: require.resolve('./sidebars.js'),
           // Equivalent to `enableUpdateBy`.
           showLastUpdateAuthor: true,


### PR DESCRIPTION
opctl no longer uses the master branch.  The edit links all point to the master branch.  They should instead point to main.

issue: https://github.com/opctl/opctl/issues/925