### PR TITLE
Add back support for deprecated output binding syntax

### DIFF
--- a/sdks/go/opspec/interpreter/call/op/outputs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/outputs/interpret.go
@@ -33,12 +33,7 @@ func Interpret(
 		if _, ok := outputParams[callOutputParamName]; !ok {
 			// maybe the user has flipped the key and value?
 			if _, ok := outputParams[opspec.RefToName(callOutputParamBoundName)]; ok {
-				return nil, fmt.Errorf(
-					"unknown output '%s', did you mean to use `%s: %s`?",
-					callOutputParamName,
-					opspec.RefToName(callOutputParamBoundName),
-					opspec.NameToRef(callOutputParamName),
-				)
+				continue
 			}
 
 			// try to figure out what the user should have provided

--- a/sdks/go/opspec/interpreter/call/op/outputs/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/op/outputs/interpret_test.go
@@ -45,25 +45,48 @@ var _ = Context("Interpret", func() {
 		Expect(actualOutputs).To(Equal(expectedOutputs))
 		Expect(actualErr).To(BeNil())
 	})
-	Describe("ensures expected outputs match actual outputs", func() {
-		It("detects inverted naming", func() {
+	Describe("deprecated output binding syntax", func() {
+		It("should return expected result", func() {
+			/* arrange */
+			arrayValue := []interface{}{"item"}
+			stringParamName := "stringParamName"
+
+			providedArgs := map[string]*model.Value{
+				stringParamName: {Array: &arrayValue},
+			}
+
+			providedParams := map[string]*model.Param{
+				stringParamName: {String: &model.StringParam{}},
+			}
+
+			providedOpCallOutputs := map[string]string{
+				"myVar": stringParamName,
+			}
+
+			arrayValueAsString, err := coerce.ToString(providedArgs[stringParamName])
+			if err != nil {
+				panic(err)
+			}
+
+			expectedOutputs := map[string]*model.Value{
+				stringParamName: arrayValueAsString,
+			}
+
 			/* act */
 			actualOutputs, actualErr := Interpret(
-				map[string]*model.Value{},
-				map[string]*model.Param{
-					"bar": {String: &model.StringParam{}},
-				},
-				map[string]string{
-					"foo": "$(bar)",
-				},
+				providedArgs,
+				providedParams,
+				providedOpCallOutputs,
 				"opPath",
 				"opScratchDir",
 			)
 
 			/* assert */
-			Expect(actualOutputs).To(BeNil())
-			Expect(actualErr).To(MatchError("unknown output 'foo', did you mean to use `bar: $(foo)`?"))
+			Expect(actualOutputs).To(Equal(expectedOutputs))
+			Expect(actualErr).To(BeNil())
 		})
+	})
+	Describe("ensures expected outputs match actual outputs", func() {
 		It("indicates what was expected when one output exists", func() {
 			/* act */
 			actualOutputs, actualErr := Interpret(

--- a/sdks/go/opspec/opfile/unmarshal_test.go
+++ b/sdks/go/opspec/opfile/unmarshal_test.go
@@ -1,6 +1,7 @@
 package opfile
 
 import (
+	"encoding/json"
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -20,19 +21,20 @@ var _ = Context("Unmarshal", func() {
 	})
 	Context("Validator.Validate doesn't return errors", func() {
 
-		XIt("should return expected opFile", func() {
+		It("should return expected opFile", func() {
 
 			/* arrange */
 			paramDefault := "dummyDefault"
+			paramName := "paramName"
 			dummyParams := map[string]*model.Param{
-				"dummyName": {
+				paramName: {
 					String: &model.StringParam{
 						Constraints: map[string]interface{}{
-							"MinLength": 0,
-							"MaxLength": 1000,
-							"Pattern":   "dummyPattern",
-							"Format":    "dummyFormat",
-							"Enum":      []interface{}{"dummyEnumItem1"},
+							"minLength": 0,
+							"maxLength": 1000,
+							"pattern":   "dummyPattern",
+							"format":    "date-time",
+							"enum":      []interface{}{"dummyEnumItem1"},
 						},
 						Default:     &paramDefault,
 						Description: "dummyDescription",
@@ -41,7 +43,7 @@ var _ = Context("Unmarshal", func() {
 				},
 			}
 
-			expectedOpFile := &model.OpSpec{
+			expectedOpFile := model.OpSpec{
 				Description: "dummyDescription",
 				Inputs:      dummyParams,
 				Name:        "dummyName",
@@ -51,19 +53,30 @@ var _ = Context("Unmarshal", func() {
 						Ref: "dummyOpRef",
 					},
 				},
-				Version: "dummyVersion",
+				Version: "0.0.0",
 			}
-			providedBytes, err := yaml.Marshal(expectedOpFile)
+			providedBytes, err := yaml.Marshal(&expectedOpFile)
 			if err != nil {
 				panic(err.Error())
 			}
 
 			/* act */
-			actualOpFile, _ := Unmarshal(providedBytes)
+			actualOpFile, actualErr := Unmarshal(providedBytes)
 
 			/* assert */
-			Expect(*actualOpFile).To(Equal(*expectedOpFile))
+			Expect(actualErr).To(BeNil())
 
+			// compare contents via JSON; otherwise we encounter pointer inequalities
+			actualBytes, err := json.Marshal(actualOpFile)
+			if err != nil {
+				panic(err)
+			}
+
+			expectedBytes, err := json.Marshal(expectedOpFile)
+			if err != nil {
+				panic(err)
+			}
+			Expect(string(actualBytes)).To(Equal(string(expectedBytes)))
 		})
 	})
 })


### PR DESCRIPTION
In the [PR to error on invalid op output names](https://github.com/opctl/opctl/pull/893), we also removed support for the original output binding syntax. This syntax was never officially deprecated yet (I consider official here to be the CHANGELOG) and the syntax is for sure in use by consumers still. We should give at least a release worth of notice and probably much more since this syntax has been around for awhile. This adds it back for now and I added a [PR to deprecate it officially](https://github.com/opctl/opctl/pull/953). 