### PR TITLE
Remove github.com/pkg/errors usage; use native golang errors

### DIFF
--- a/cli/internal/datadir/datadir.go
+++ b/cli/internal/datadir/datadir.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 
 	"github.com/golang-utils/lockfile"
-	"github.com/pkg/errors"
 )
 
 // DataDir is an interface exposing the functionality we require in conjunction with our "data dir".
@@ -36,11 +35,11 @@ func New(
 ) (DataDir, error) {
 	resolvedDataDirPath, err := filepath.Abs(dataDirPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "error initializing opctl data dir")
+		return nil, fmt.Errorf("error initializing opctl data dir: %w", err)
 	}
 
 	if err := ensureExists(resolvedDataDirPath); err != nil {
-		return nil, errors.Wrap(err, "error initializing opctl data dir")
+		return nil, fmt.Errorf("error initializing opctl data dir: %w", err)
 	}
 
 	// ensure we can write
@@ -49,7 +48,7 @@ func New(
 		[]byte(""),
 		0775,
 	); err != nil {
-		return nil, errors.Wrap(err, "error initializing opctl data dir")
+		return nil, fmt.Errorf("error initializing opctl data dir: %w", err)
 	}
 
 	return _datadir{

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_unix.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_unix.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 
 	"github.com/opctl/opctl/sdks/go/node"
-	"github.com/pkg/errors"
 )
 
 func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, error) {
@@ -77,7 +76,7 @@ func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, er
 	nodeLogBytes, _ := ioutil.ReadFile(nodeLogFilePath)
 	fmt.Println(string(nodeLogBytes))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create daemonized opctl node")
+		return nil, fmt.Errorf("failed to create daemonized opctl node: %w", err)
 	}
 
 	return apiClientNode, nil

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists_windows.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists_windows.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/opctl/opctl/sdks/go/node"
-	"github.com/pkg/errors"
 )
 
 func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, error) {
@@ -75,7 +74,7 @@ func (np nodeProvider) CreateNodeIfNotExists(ctx context.Context) (node.Node, er
 	nodeLogBytes, _ := ioutil.ReadFile(nodeLogFilePath)
 	fmt.Println(string(nodeLogBytes))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create daemonized opctl node")
+		return nil, fmt.Errorf("failed to create daemonized opctl node: %w", err)
 	}
 
 	return apiClientNode, nil

--- a/cli/run.go
+++ b/cli/run.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,7 +16,6 @@ import (
 	"github.com/opctl/opctl/cli/internal/nodeprovider"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
-	"github.com/pkg/errors"
 )
 
 // run implements "run" command
@@ -72,7 +72,7 @@ func run(
 
 	ymlFileInputSrc, err := cliParamSatisfier.NewYMLFileInputSrc(argFile)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to load arg file at '%v'", argFile))
+		return fmt.Errorf("unable to load arg file at '%v': %w", argFile, err)
 	}
 
 	argsMap, err := cliParamSatisfier.Satisfy(

--- a/cli/selfUpdate.go
+++ b/cli/selfUpdate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/opctl/opctl/cli/internal/nodeprovider"
-	"github.com/pkg/errors"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 )
 
@@ -26,7 +25,7 @@ func selfUpdate(
 	// @TODO start node maintaining previous user
 	err = nodeProvider.KillNodeIfExists("")
 	if err != nil {
-		err = errors.Wrap(err, "unable to kill running node; run `node kill` to complete the update")
+		err = fmt.Errorf("unable to kill running node; run `node kill` to complete the update: %w", err)
 	}
 	return fmt.Sprintf("Updated to new version: %s!", latest.Version), err
 }

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.9.0
 	github.com/peterh/liner v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7-0.20191104211043-6b2f3ee522b6
 	github.com/rhysd/go-github-selfupdate v1.2.3
 	github.com/satori/go.uuid v0.0.0-20181028125025-b2ce2384e17b

--- a/sdks/go/data/coerce/errors.go
+++ b/sdks/go/data/coerce/errors.go
@@ -1,7 +1,7 @@
 package coerce
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 var errIncompatibleTypes = errors.New("incompatible types")

--- a/sdks/go/data/coerce/toArray.go
+++ b/sdks/go/data/coerce/toArray.go
@@ -2,11 +2,11 @@ package coerce
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToArray coerces a value to an array value
@@ -19,29 +19,29 @@ func ToArray(
 	case value.Array != nil:
 		return value, nil
 	case value.Boolean != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce boolean to array")
+		return nil, fmt.Errorf("unable to coerce boolean to array: %w", errIncompatibleTypes)
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to array")
+		return nil, fmt.Errorf("unable to coerce dir to array: %w", errIncompatibleTypes)
 	case value.File != nil:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to array")
+			return nil, fmt.Errorf("unable to coerce file to array: %w", err)
 		}
 		valueArray := new([]interface{})
 		err = json.Unmarshal([]byte(fileBytes), valueArray)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to array")
+			return nil, fmt.Errorf("unable to coerce file to array: %w", err)
 		}
 		return &model.Value{Array: valueArray}, nil
 	case value.Number != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce number to array")
+		return nil, fmt.Errorf("unable to coerce number to array: %w", errIncompatibleTypes)
 	case value.Socket != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce socket to array")
+		return nil, fmt.Errorf("unable to coerce socket to array: %w", errIncompatibleTypes)
 	case value.String != nil:
 		valueArray := new([]interface{})
 		err := json.Unmarshal([]byte(*value.String), valueArray)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce string to array")
+			return nil, fmt.Errorf("unable to coerce string to array: %w", err)
 		}
 		return &model.Value{Array: valueArray}, nil
 	default:

--- a/sdks/go/data/coerce/toBoolean.go
+++ b/sdks/go/data/coerce/toBoolean.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // isStringTruthy ensures value isn't:
@@ -37,11 +36,11 @@ func ToBoolean(
 	case value.Boolean != nil:
 		return value, nil
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to boolean")
+		return nil, fmt.Errorf("unable to coerce dir to boolean: %w", errIncompatibleTypes)
 	case value.File != nil:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to boolean")
+			return nil, fmt.Errorf("unable to coerce file to boolean: %w", err)
 		}
 
 		booleanValue := isStringTruthy(string(fileBytes))

--- a/sdks/go/data/coerce/toDir.go
+++ b/sdks/go/data/coerce/toDir.go
@@ -1,6 +1,7 @@
 package coerce
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,7 +10,6 @@ import (
 
 	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToDir attempts to coerce value to a dir
@@ -21,32 +21,32 @@ func ToDir(
 	case value == nil:
 		return nil, errors.New("unable to coerce null to dir")
 	case value.Array != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to dir")
+		return nil, fmt.Errorf("unable to coerce array to dir: %w", errIncompatibleTypes)
 	case value.Boolean != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce boolean to dir")
+		return nil, fmt.Errorf("unable to coerce boolean to dir: %w", errIncompatibleTypes)
 	case value.Dir != nil:
 		return value, nil
 	case value.File != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce file to dir")
+		return nil, fmt.Errorf("unable to coerce file to dir: %w", errIncompatibleTypes)
 	case value.Number != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce number to dir")
+		return nil, fmt.Errorf("unable to coerce number to dir: %w", errIncompatibleTypes)
 	case value.Object != nil:
 		uniqueStr, err := uniquestring.Construct()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to dir")
+			return nil, fmt.Errorf("unable to coerce object to dir: %w", err)
 		}
 
 		rootDirPath := filepath.Join(scratchDir, uniqueStr)
 		err = rCreateFileItem(rootDirPath, "", *value.Object)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to dir")
+			return nil, fmt.Errorf("unable to coerce object to dir: %w", err)
 		}
 
 		return &model.Value{Dir: &rootDirPath}, nil
 	case value.Socket != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce socket to dir")
+		return nil, fmt.Errorf("unable to coerce socket to dir: %w", errIncompatibleTypes)
 	case value.String != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce string to dir")
+		return nil, fmt.Errorf("unable to coerce string to dir: %w", errIncompatibleTypes)
 	default:
 		return nil, fmt.Errorf("unable to coerce '%+v' to dir", value)
 	}
@@ -73,12 +73,12 @@ func rCreateFileItem(
 			0777,
 		)
 		if err != nil {
-			return errors.Wrap(err, "error creating "+itemPath)
+			return fmt.Errorf("error creating %s: %w", itemPath, err)
 		}
 
 		err = ioutil.WriteFile(itemPath, []byte(dataString), 0777)
 		if err != nil {
-			return errors.Wrap(err, "error creating "+itemPath)
+			return fmt.Errorf("error creating %s: %w", itemPath, err)
 		}
 
 		return nil
@@ -90,7 +90,7 @@ func rCreateFileItem(
 		0777,
 	)
 	if err != nil {
-		return errors.Wrap(err, "error creating "+itemPath)
+		return fmt.Errorf("error creating %s: %w", itemPath, err)
 	}
 
 	for k, v := range children {

--- a/sdks/go/data/coerce/toFile.go
+++ b/sdks/go/data/coerce/toFile.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/opctl/opctl/sdks/go/internal/uniquestring"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToFile attempts to coerce value to a file
@@ -26,17 +25,17 @@ func ToFile(
 	case value.Array != nil:
 		nativeArray, err := value.Unbox()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce array to file")
+			return nil, fmt.Errorf("unable to coerce array to file: %w", err)
 		}
 
 		data, err = json.Marshal(nativeArray)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce array to file")
+			return nil, fmt.Errorf("unable to coerce array to file: %w", err)
 		}
 	case value.Boolean != nil:
 		data = []byte(strconv.FormatBool(*value.Boolean))
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to file", *value.Dir))
+		return nil, fmt.Errorf("unable to coerce dir '%v' to file: %w", *value.Dir, errIncompatibleTypes)
 	case value.File != nil:
 		return value, nil
 	case value.Number != nil:
@@ -44,12 +43,12 @@ func ToFile(
 	case value.Object != nil:
 		nativeObject, err := value.Unbox()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to file")
+			return nil, fmt.Errorf("unable to coerce object to file: %w", err)
 		}
 
 		data, err = json.Marshal(nativeObject)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to file")
+			return nil, fmt.Errorf("unable to coerce object to file: %w", err)
 		}
 	case value.String != nil:
 		data = []byte(*value.String)
@@ -60,7 +59,7 @@ func ToFile(
 
 	uniqueStr, err := uniquestring.Construct()
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to coerce '%+v' to file", value))
+		return nil, fmt.Errorf("unable to coerce '%+v' to file: %w", value, err)
 	}
 
 	path := filepath.Join(scratchDir, uniqueStr)
@@ -82,7 +81,7 @@ func ToFile(
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to coerce '%+v' to file", value))
+		return nil, fmt.Errorf("unable to coerce '%+v' to file: %w", value, err)
 	}
 
 	return &model.Value{File: &path}, nil

--- a/sdks/go/data/coerce/toNumber.go
+++ b/sdks/go/data/coerce/toNumber.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToNumber coerces a value to a number value
@@ -17,28 +16,28 @@ func ToNumber(
 	case value == nil:
 		return &model.Value{Number: new(float64)}, nil
 	case value.Array != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to number")
+		return nil, fmt.Errorf("unable to coerce array to number: %w", errIncompatibleTypes)
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce dir to number")
+		return nil, fmt.Errorf("unable to coerce dir to number: %w", errIncompatibleTypes)
 	case value.File != nil:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to number")
+			return nil, fmt.Errorf("unable to coerce file to number: %w", err)
 		}
 
 		float64Value, err := strconv.ParseFloat(string(fileBytes), 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to number")
+			return nil, fmt.Errorf("unable to coerce file to number: %w", err)
 		}
 		return &model.Value{Number: &float64Value}, nil
 	case value.Number != nil:
 		return value, nil
 	case value.Object != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce object to number")
+		return nil, fmt.Errorf("unable to coerce object to number: %w", errIncompatibleTypes)
 	case value.String != nil:
 		float64Value, err := strconv.ParseFloat(*value.String, 64)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce string to number")
+			return nil, fmt.Errorf("unable to coerce string to number: %w", err)
 		}
 		return &model.Value{Number: &float64Value}, nil
 	default:

--- a/sdks/go/data/coerce/toObject.go
+++ b/sdks/go/data/coerce/toObject.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToObject coerces a value to an object value
@@ -17,29 +16,29 @@ func ToObject(
 	case value == nil:
 		return nil, nil
 	case value.Array != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, "unable to coerce array to object")
+		return nil, fmt.Errorf("unable to coerce array to object: %w", errIncompatibleTypes)
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to object", *value.Dir))
+		return nil, fmt.Errorf("unable to coerce dir '%v' to object: %w", *value.Dir, errIncompatibleTypes)
 	case value.File != nil:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to object")
+			return nil, fmt.Errorf("unable to coerce file to object: %w", err)
 		}
 		valueMap := &map[string]interface{}{}
 		err = json.Unmarshal([]byte(fileBytes), valueMap)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to object")
+			return nil, fmt.Errorf("unable to coerce file to object: %w", err)
 		}
 		return &model.Value{Object: valueMap}, nil
 	case value.Number != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce number '%v' to object", *value.Number))
+		return nil, fmt.Errorf("unable to coerce number '%v' to object: %w", *value.Number, errIncompatibleTypes)
 	case value.Object != nil:
 		return value, nil
 	case value.String != nil:
 		valueMap := &map[string]interface{}{}
 		err := json.Unmarshal([]byte(*value.String), valueMap)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce string to object")
+			return nil, fmt.Errorf("unable to coerce string to object: %w", err)
 		}
 		return &model.Value{Object: valueMap}, nil
 	default:

--- a/sdks/go/data/coerce/toString.go
+++ b/sdks/go/data/coerce/toString.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // ToString coerces a value to a string value
@@ -20,12 +19,12 @@ func ToString(
 	case value.Array != nil:
 		nativeArray, err := value.Unbox()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce array to string")
+			return nil, fmt.Errorf("unable to coerce array to string: %w", err)
 		}
 
 		arrayBytes, err := json.Marshal(nativeArray)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce array to string")
+			return nil, fmt.Errorf("unable to coerce array to string: %w", err)
 		}
 		arrayString := string(arrayBytes)
 		return &model.Value{String: &arrayString}, nil
@@ -33,11 +32,11 @@ func ToString(
 		booleanString := strconv.FormatBool(*value.Boolean)
 		return &model.Value{String: &booleanString}, nil
 	case value.Dir != nil:
-		return nil, errors.Wrap(errIncompatibleTypes, fmt.Sprintf("unable to coerce dir '%v' to string", *value.Dir))
+		return nil, fmt.Errorf("unable to coerce dir '%v' to string: %w", *value.Dir, errIncompatibleTypes)
 	case value.File != nil:
 		fileBytes, err := ioutil.ReadFile(*value.File)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce file to string")
+			return nil, fmt.Errorf("unable to coerce file to string: %w", err)
 		}
 		fileString := string(fileBytes)
 		return &model.Value{String: &fileString}, nil
@@ -47,12 +46,12 @@ func ToString(
 	case value.Object != nil:
 		nativeObject, err := value.Unbox()
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to string")
+			return nil, fmt.Errorf("unable to coerce object to string: %w", err)
 		}
 
 		objectBytes, err := json.Marshal(nativeObject)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to coerce object to string")
+			return nil, fmt.Errorf("unable to coerce object to string: %w", err)
 		}
 		objectString := string(objectBytes)
 		return &model.Value{String: &objectString}, nil

--- a/sdks/go/data/git/pull.go
+++ b/sdks/go/data/git/pull.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // Pull pulls 'dataRef' to 'path'
@@ -29,7 +29,7 @@ func Pull(
 
 	parsedPkgRef, err := parseRef(dataRef)
 	if err != nil {
-		return errors.Wrap(err, "invalid git ref")
+		return fmt.Errorf("invalid git ref: %w", err)
 	}
 
 	opPath := parsedPkgRef.ToPath(path)

--- a/sdks/go/data/resolve.go
+++ b/sdks/go/data/resolve.go
@@ -6,7 +6,6 @@ import (
 
 	aggregateError "github.com/opctl/opctl/sdks/go/internal/aggregate_error"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // Resolve "dataRef" from "providers" in order
@@ -27,11 +26,11 @@ func Resolve(
 	for _, src := range providers {
 		handle, err := src.TryResolve(ctx, dataRef)
 		if err != nil {
-			agg.AddError(errors.Wrap(err, src.Label()))
+			agg.AddError(fmt.Errorf("%s: %w", src.Label(), err))
 		} else if handle != nil {
 			return handle, nil
 		}
 	}
 
-	return nil, errors.Wrap(agg, fmt.Sprintf("unable to resolve op '%s'", dataRef))
+	return nil, fmt.Errorf("unable to resolve op '%s': %w", dataRef, agg)
 }

--- a/sdks/go/data/resolve_test.go
+++ b/sdks/go/data/resolve_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/fs"
 	aggregateError "github.com/opctl/opctl/sdks/go/internal/aggregate_error"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 var _ = Context("Resolve", func() {
@@ -31,8 +31,8 @@ var _ = Context("Resolve", func() {
 
 			/* assert */
 			var expected aggregateError.ErrAggregate
-			expected.AddError(errors.Wrap(fmt.Errorf("skipped"), provider0.Label()))
-			Expect(actualErr).To(MatchError(errors.Wrap(expected, "unable to resolve op '\\not/exist'").Error()))
+			expected.AddError(fmt.Errorf("%s: %w", provider0.Label(), errors.New("skipped")))
+			Expect(actualErr).To(MatchError(fmt.Errorf("unable to resolve op '\\not/exist': %w", expected)))
 		})
 	})
 	Context("providers[0].TryResolve doesn't err", func() {

--- a/sdks/go/internal/aggregate_error/aggregate_error.go
+++ b/sdks/go/internal/aggregate_error/aggregate_error.go
@@ -2,16 +2,15 @@ package errors
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // ErrAggregate aggregates multiple errors into one, in a tree format
-// instead of a linked list like `.Wrap` does.
+// instead of a linked list like `fmt.Errorf` does.
 //
-// They should always be wrapped with `errors.Wrap(err, "label")` to give them
+// They should always be wrapped with `fmt.Errorf("%s: %w", "label", err)` to give them
 // context.
 type ErrAggregate struct {
 	errs []error

--- a/sdks/go/internal/aggregate_error/aggregate_error_test.go
+++ b/sdks/go/internal/aggregate_error/aggregate_error_test.go
@@ -1,11 +1,12 @@
 package errors
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 func TestAggregateError(t *testing.T) {
@@ -15,12 +16,12 @@ func TestAggregateError(t *testing.T) {
 	internalErr := errors.New("testing")
 	err := ErrAggregate{
 		errs: []error{
-			errors.Wrap(ErrAggregate{
+			fmt.Errorf("container: %w", ErrAggregate{
 				errs: []error{
 					errors.New("nested"),
 					model.ErrDataProviderAuthorization{},
 				},
-			}, "container"),
+			}),
 			internalErr,
 		},
 	}

--- a/sdks/go/model/data.go
+++ b/sdks/go/model/data.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 type ReadSeekCloser interface {
@@ -96,7 +94,7 @@ func (value Value) Unbox() (interface{}, error) {
 			case Value:
 				nativeItem, err := typedItemValue.Unbox()
 				if err != nil {
-					return nil, errors.Wrap(err, fmt.Sprintf("unable to unbox item '%v' from array", itemKey))
+					return nil, fmt.Errorf("unable to unbox item '%v' from array: %w", itemKey, err)
 				}
 
 				nativeArray = append(nativeArray, nativeItem)
@@ -120,7 +118,7 @@ func (value Value) Unbox() (interface{}, error) {
 			case Value:
 				var err error
 				if nativeObject[propKey], err = typedPropValue.Unbox(); err != nil {
-					return nil, errors.Wrap(err, fmt.Sprintf("unable to unbox property '%v' from object", propKey))
+					return nil, fmt.Errorf("unable to unbox property '%v' from object: %w", propKey, err)
 				}
 			default:
 				nativeObject[propKey] = propValue

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists.go
@@ -1,8 +1,9 @@
 package docker
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
 
@@ -19,7 +20,7 @@ func (ctp _containerRuntime) DeleteContainerIfExists(
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, "unable to delete container")
+		return fmt.Errorf("unable to delete container: %w", err)
 	}
 
 	return nil

--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
@@ -2,12 +2,11 @@ package docker
 
 import (
 	"context"
-
+	"errors"
 	"github.com/docker/docker/api/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/internal/fakes"
-	"github.com/pkg/errors"
 )
 
 var _ = Context("DeleteContainerIfExists", func() {

--- a/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser.go
+++ b/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser.go
@@ -1,9 +1,10 @@
 package docker
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/api/types"
 	dockerClientPkg "github.com/docker/docker/client"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/sync/singleflight"
 )
@@ -45,7 +46,7 @@ func (ene _ensureNetworkExistser) EnsureNetworkExists(
 	}
 
 	if !dockerClientPkg.IsErrNotFound(networkInspectErr) {
-		return errors.Wrap(networkInspectErr, "unable to inspect network")
+		return fmt.Errorf("unable to inspect network: %w", networkInspectErr)
 	}
 
 	// attempt to resolve within singleFlight.Group to ensure concurrent creates don't race
@@ -63,7 +64,7 @@ func (ene _ensureNetworkExistser) EnsureNetworkExists(
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, "unable to create network")
+		return fmt.Errorf("unable to create network: %w", err)
 	}
 
 	return nil

--- a/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser_test.go
+++ b/sdks/go/node/core/containerruntime/docker/ensureNetworkExistser_test.go
@@ -2,12 +2,12 @@ package docker
 
 import (
 	"context"
+	"errors"
 
 	"github.com/docker/docker/api/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/internal/fakes"
-	"github.com/pkg/errors"
 )
 
 var _ = Context("EnsureNetworkExistser", func() {

--- a/sdks/go/node/core/containerruntime/docker/fsPathConverter.go
+++ b/sdks/go/node/core/containerruntime/docker/fsPathConverter.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"regexp"
 	"strings"
@@ -9,7 +10,6 @@ import (
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/opctl/opctl/sdks/go/internal/iruntime"
 	"github.com/opctl/opctl/sdks/go/node/core/containerruntime/docker/hostruntime"
-	"github.com/pkg/errors"
 )
 
 //counterfeiter:generate -o internal/fakes/fsPathConverter.go . fsPathConverter
@@ -23,7 +23,7 @@ func newFSPathConverter(
 ) (fsPathConverter, error) {
 	hr, err := hostruntime.New(ctx, dockerClient)
 	if err != nil {
-		return _fsPathConverter{}, errors.Wrap(err, "error detecting docker host runtime")
+		return _fsPathConverter{}, fmt.Errorf("error detecting docker host runtime: %w", err)
 	}
 	pc := _fsPathConverter{
 		runtime:     iruntime.New(),

--- a/sdks/go/node/core/containerruntime/docker/hostruntime/runtimeinfo.go
+++ b/sdks/go/node/core/containerruntime/docker/hostruntime/runtimeinfo.go
@@ -2,11 +2,11 @@ package hostruntime
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
-	"github.com/pkg/errors"
 )
 
 // RuntimeInfo provides relation between opctl and docker engine host
@@ -32,14 +32,14 @@ func newContainerRuntimeInfo(ctx context.Context, cli containerInspector, cu con
 	if cu.inAContainer() {
 		dockerID, err := cu.getDockerID()
 		if err != nil {
-			return cri, errors.Wrap(err, "can't get container's docker id")
+			return cri, fmt.Errorf("can't get container's docker id: %w", err)
 		}
 
 		cri.DockerID = dockerID
 
 		info, exists, err := inspect(ctx, cli, dockerID)
 		if err != nil {
-			return cri, errors.Wrap(err, "can't get inspect current container")
+			return cri, fmt.Errorf("can't get inspect current container: %w", err)
 		}
 
 		if exists {

--- a/sdks/go/node/core/containerruntime/docker/imagePusher.go
+++ b/sdks/go/node/core/containerruntime/docker/imagePusher.go
@@ -2,13 +2,13 @@ package docker
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containers/image/v5/copy"
 	"github.com/containers/image/v5/docker/daemon"
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/signature"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 //counterfeiter:generate -o internal/fakes/imagePusher.go . imagePusher
@@ -39,21 +39,21 @@ func (ip _imagePusher) Push(
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, "error loading image")
+		return fmt.Errorf("error loading image: %w", err)
 	}
 
 	srcImageRef, err := layout.NewReference(*imageSrc.Dir, "")
 	if err != nil {
-		return errors.Wrap(err, "error loading image")
+		return fmt.Errorf("error loading image: %w", err)
 	}
 
 	dstImageRef, err := daemon.ParseReference(imageRef)
 	if err != nil {
-		return errors.Wrap(err, "error loading image")
+		return fmt.Errorf("error loading image: %w", err)
 	}
 
 	if _, err := copy.Image(ctx, policyCtx, dstImageRef, srcImageRef, nil); err != nil {
-		return errors.Wrap(err, "error loading image")
+		return fmt.Errorf("error loading image: %w", err)
 	}
 
 	return nil

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"sync"
 
+	"errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	dockerClientPkg "github.com/docker/docker/client"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/pubsub"
-	"github.com/pkg/errors"
 )
 
 type runContainer interface {
@@ -212,7 +212,7 @@ func (cr _runContainer) RunContainer(
 	case waitOk := <-waitOkChan:
 		exitCode = waitOk.StatusCode
 	case waitErr := <-waitErrChan:
-		err = errors.Wrap(waitErr, "error waiting on container")
+		err = fmt.Errorf("error waiting on container: %w", waitErr)
 	}
 
 	// ensure stdout, and stderr all read before returning

--- a/sdks/go/node/core/containerruntime/k8s/containerRuntime.go
+++ b/sdks/go/node/core/containerruntime/k8s/containerRuntime.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/node/core/containerruntime"
 	"github.com/opctl/opctl/sdks/go/pubsub"
-	"github.com/pkg/errors"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -48,7 +47,7 @@ func (cr _containerRuntime) DeleteContainerIfExists(
 		constructPodName(containerID),
 		metaV1.DeleteOptions{},
 	); err != nil {
-		return errors.Wrap(err, "unable to delete k8s container")
+		return fmt.Errorf("unable to delete k8s container: %w", err)
 	}
 
 	return nil
@@ -108,7 +107,7 @@ func (cr _containerRuntime) RunContainer(
 			)
 			logSrc, err := logsResult.Stream(ctx)
 			if err != nil {
-				return nil, errors.Wrap(err, "running LogStreamError")
+				return nil, fmt.Errorf("unable to stream running pod logs from k8s: %w", err)
 			}
 			defer logSrc.Close()
 
@@ -131,7 +130,7 @@ func (cr _containerRuntime) RunContainer(
 			)
 			logSrc, err := logsResult.Stream(ctx)
 			if err != nil {
-				return nil, errors.Wrap(err, "failed, LogStreamError")
+				return nil, fmt.Errorf("unable to stream failed pod logs from k8s: %w", err)
 			}
 			defer logSrc.Close()
 			_, err = io.Copy(stdout, logSrc)

--- a/sdks/go/opspec/interpreter/array/interpret.go
+++ b/sdks/go/opspec/interpreter/array/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to an array value.
@@ -21,7 +20,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to array", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to array: %w", expression, err)
 	}
 
 	return coerce.ToArray(&v)

--- a/sdks/go/opspec/interpreter/boolean/interpret.go
+++ b/sdks/go/opspec/interpreter/boolean/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a boolean value.
@@ -20,7 +19,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to boolean", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to boolean: %w", expression, err)
 	}
 
 	return coerce.ToBoolean(&v)

--- a/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/dirs/interpret.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
-	"github.com/pkg/errors"
 )
 
 // Interpret container dirs
@@ -35,11 +34,7 @@ dirLoop:
 			true,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind directory %v to %v",
-				callSpecContainerDirPath,
-				dirExpression,
-			))
+			return nil, fmt.Errorf("unable to bind directory %v to %v: %w", callSpecContainerDirPath, dirExpression, err)
 		}
 
 		if *dirValue.Dir != "" && !strings.HasPrefix(*dirValue.Dir, dataCachePath) {
@@ -56,11 +51,7 @@ dirLoop:
 			*dirValue.Dir,
 			containerCallDirs[callSpecContainerDirPath],
 		); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind %v to %v",
-				callSpecContainerDirPath,
-				dirExpression,
-			))
+			return nil, fmt.Errorf("unable to bind %v to %v: %w", callSpecContainerDirPath, dirExpression, err)
 		}
 
 	}

--- a/sdks/go/opspec/interpreter/call/container/envvars/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/envvars/interpret.go
@@ -7,7 +7,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/object"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret container envVars
@@ -24,26 +23,19 @@ func Interpret(
 		containerCallSpecEnvVars,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf(
-			"unable to interpret '%v' as envVars",
-			containerCallSpecEnvVars,
-		))
+		return nil, fmt.Errorf("unable to interpret '%v' as envVars: %w", containerCallSpecEnvVars, err)
 	}
 
 	envVarsStringMap := map[string]string{}
 	for envVarName, envVarValueInterface := range *envVarsMap.Object {
 		envVarValue, err := value.Construct(envVarValueInterface)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to construct value for env var '%s'", envVarName))
+			return nil, fmt.Errorf("unable to construct value for env var '%s': %w", envVarName, err)
 		}
 
 		envVarValueString, err := coerce.ToString(envVarValue)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to interpret '%+v' as value of env var '%v'",
-				envVarValue,
-				envVarName,
-			))
+			return nil, fmt.Errorf("unable to interpret '%+v' as value of env var '%v': %w", envVarValue, envVarName, err)
 		}
 
 		envVarsStringMap[envVarName] = *envVarValueString.String

--- a/sdks/go/opspec/interpreter/call/container/files/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/files/interpret.go
@@ -11,7 +11,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/file"
-	"github.com/pkg/errors"
 )
 
 // Interpret container files
@@ -37,11 +36,7 @@ fileLoop:
 			true,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind file %v to %v",
-				callSpecContainerFilePath,
-				fileExpression,
-			))
+			return nil, fmt.Errorf("unable to bind file %v to %v: %w", callSpecContainerFilePath, fileExpression, err)
 		}
 
 		if !strings.HasPrefix(*fileValue.File, dataCachePath) {
@@ -58,11 +53,7 @@ fileLoop:
 			filepath.Dir(containerCallFiles[callSpecContainerFilePath]),
 			0777,
 		); err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind %v to %v",
-				callSpecContainerFilePath,
-				fileExpression,
-			))
+			return nil, fmt.Errorf("unable to bind %v to %v: %w", callSpecContainerFilePath, fileExpression, err)
 		}
 
 		// copy file
@@ -72,11 +63,7 @@ fileLoop:
 			containerCallFiles[callSpecContainerFilePath],
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf(
-				"unable to bind %v to %v",
-				callSpecContainerFilePath,
-				fileExpression,
-			))
+			return nil, fmt.Errorf("unable to bind %v to %v: %w", callSpecContainerFilePath, fileExpression, err)
 		}
 
 	}

--- a/sdks/go/opspec/interpreter/call/container/image/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/image/interpret.go
@@ -1,13 +1,14 @@
 package image
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/docker/distribution/reference"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
-	"github.com/pkg/errors"
 )
 
 // Interpret container image
@@ -55,12 +56,12 @@ func Interpret(
 	if containerCallImageSpec.PullCreds != nil {
 		username, err := str.Interpret(scope, containerCallImageSpec.PullCreds.Username)
 		if err != nil {
-			return nil, errors.Wrap(err, "error encountered interpreting image pullcreds username")
+			return nil, fmt.Errorf("error encountered interpreting image pullcreds username: %w", err)
 		}
 
 		password, err := str.Interpret(scope, containerCallImageSpec.PullCreds.Password)
 		if err != nil {
-			return nil, errors.Wrap(err, "error encountered interpreting image pullcreds password")
+			return nil, fmt.Errorf("error encountered interpreting image pullcreds password: %w", err)
 		}
 
 		containerCallImage.PullCreds = &model.Creds{

--- a/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/inputs/input/interpret.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/object"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
-	"github.com/pkg/errors"
 )
 
 //Interpret interprets an op input
@@ -42,43 +41,43 @@ func Interpret(
 	case param.Array != nil:
 		arrayValue, err := array.Interpret(scope, valueExpression)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return arrayValue, nil
 	case param.Boolean != nil:
 		booleanValue, err := boolean.Interpret(scope, valueExpression)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return booleanValue, nil
 	case param.File != nil:
 		fileValue, err := file.Interpret(scope, valueExpression, opScratchDir, true)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return fileValue, nil
 	case param.Dir != nil:
 		dirValue, err := dir.Interpret(scope, valueExpression, opScratchDir, true)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return dirValue, nil
 	case param.Number != nil:
 		numberValue, err := number.Interpret(scope, valueExpression)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return numberValue, nil
 	case param.Object != nil:
 		objectValue, err := object.Interpret(scope, valueExpression)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return objectValue, nil
 	case param.String != nil:
 		stringValue, err := str.Interpret(scope, valueExpression)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		return stringValue, nil
 	case param.Socket != nil:
@@ -89,7 +88,7 @@ func Interpret(
 
 		socketValue, err := reference.Interpret(stringValueExpression, scope, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to bind '%v' to '%+v'", name, valueExpression))
+			return nil, fmt.Errorf("unable to bind '%v' to '%+v': %w", name, valueExpression, err)
 		}
 		if socketValue.Socket == nil {
 			return nil, fmt.Errorf("unable to bind '%v' to '%+v': '%+v' must reference a socket", name, valueExpression, valueExpression)

--- a/sdks/go/opspec/interpreter/call/op/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/interpret.go
@@ -15,7 +15,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
-	"github.com/pkg/errors"
 )
 
 // Interpret interprets an OpCallSpec into a OpCall
@@ -48,7 +47,7 @@ func Interpret(
 	}
 
 	var opPath string
-	if regexp.MustCompile("^\\$\\(.+\\)$").MatchString(opCallSpec.Ref) {
+	if regexp.MustCompile(`^\$\(.+\)$`).MatchString(opCallSpec.Ref) {
 		// attempt to process as a variable reference since its variable reference like.
 		dirValue, err := dir.Interpret(
 			scope,
@@ -57,7 +56,7 @@ func Interpret(
 			false,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "error encountered interpreting image src")
+			return nil, fmt.Errorf("error encountered interpreting image src: %w", err)
 		}
 		opPath = *dirValue.Dir
 	} else {
@@ -103,7 +102,7 @@ func Interpret(
 		scratchDirPath,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret call to %v", opCallSpec.Ref))
+		return nil, fmt.Errorf("unable to interpret call to %v: %w", opCallSpec.Ref, err)
 	}
 
 	return opCall, nil

--- a/sdks/go/opspec/interpreter/call/op/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/op/interpret_test.go
@@ -1,0 +1,77 @@
+package op
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+var _ = Context("Interpret", func() {
+	It("should return expected result", func() {
+		/* arrange */
+		providedOpId := "opID"
+		dataDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			panic(err)
+		}
+
+		wd, err := os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+
+		opRef := "testdata/interpret"
+
+		expectedResult := model.OpCall{
+			BaseCall: model.BaseCall{
+				OpPath: path.Join(wd, opRef),
+			},
+			ChildCallCallSpec: &model.CallSpec{
+				Container: &model.ContainerCallSpec{
+					Image: &model.ContainerCallImageSpec{
+						Ref: "alpine",
+					},
+				},
+			},
+			Inputs: map[string]*model.Value{},
+			OpID:   providedOpId,
+		}
+
+		/* act */
+		actualResult, actualError := Interpret(
+			context.Background(),
+			map[string]*model.Value{},
+			&model.OpCallSpec{
+				Ref: opRef,
+			},
+			providedOpId,
+			wd,
+			dataDir,
+		)
+
+		/* assert */
+		Expect(actualError).To((BeNil()))
+
+		// ignore ChildCallID; it's dynamic
+		expectedResult.ChildCallID = actualResult.ChildCallID
+
+		// compare as JSON; otherwise we encounter pointer inequalities
+		actualBytes, err := json.Marshal(actualResult)
+		if err != nil {
+			panic(err)
+		}
+
+		expectedBytes, err := json.Marshal(expectedResult)
+		if err != nil {
+			panic(err)
+		}
+
+		Expect(actualBytes).To(Equal(expectedBytes))
+	})
+})

--- a/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
@@ -2,12 +2,13 @@ package array
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -35,7 +36,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
@@ -47,13 +48,16 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
 		for _, errString := range result.Errors() {
 			// enum validation errors include `(root) ` prefix we don't want
-			errs = append(errs, errors.New(strings.TrimPrefix(errString.Description(), "(root) ")))
+			errs = append(
+				errs,
+				errors.New(strings.TrimPrefix(errString.Description(), "(root) ")),
+			)
 		}
 
 		return errs

--- a/sdks/go/opspec/interpreter/call/op/params/param/number/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/number/validate.go
@@ -2,12 +2,13 @@ package number
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -33,7 +34,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
@@ -45,13 +46,16 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
 		for _, errString := range result.Errors() {
 			// enum validation errors include `(root) ` prefix we don't want
-			errs = append(errs, errors.New(strings.TrimPrefix(errString.Description(), "(root) ")))
+			errs = append(
+				errs,
+				errors.New(strings.TrimPrefix(errString.Description(), "(root) ")),
+			)
 		}
 
 		return errs

--- a/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
@@ -2,12 +2,13 @@ package object
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -36,7 +37,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
@@ -48,13 +49,16 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
 		for _, errString := range result.Errors() {
 			// enum validation errors include `(root) ` prefix we don't want
-			errs = append(errs, errors.New(strings.TrimPrefix(errString.Description(), "(root) ")))
+			errs = append(
+				errs,
+				errors.New(strings.TrimPrefix(errString.Description(), "(root) ")),
+			)
 		}
 
 		return errs

--- a/sdks/go/opspec/interpreter/call/op/params/param/str/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/str/validate.go
@@ -2,12 +2,13 @@ package str
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op/params/param/formats"
-	"github.com/pkg/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -36,7 +37,7 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
@@ -48,13 +49,16 @@ func Validate(
 			// handle syntax errors specially
 			return append(
 				errs,
-				errors.Wrap(err, "error validating parameter"),
+				fmt.Errorf("error validating parameter: %w", err),
 			)
 		}
 
 		for _, errString := range result.Errors() {
 			// enum validation errors include `(root) ` prefix we don't want
-			errs = append(errs, errors.New(strings.TrimPrefix(errString.Description(), "(root) ")))
+			errs = append(
+				errs,
+				errors.New(strings.TrimPrefix(errString.Description(), "(root) ")),
+			)
 		}
 
 		return errs

--- a/sdks/go/opspec/interpreter/call/op/testdata/interpret/op.yml
+++ b/sdks/go/opspec/interpreter/call/op/testdata/interpret/op.yml
@@ -1,0 +1,5 @@
+name: interpret
+run:
+  container:
+    image:
+      ref: alpine

--- a/sdks/go/opspec/interpreter/dir/interpret.go
+++ b/sdks/go/opspec/interpreter/dir/interpret.go
@@ -8,7 +8,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a dir value.
@@ -27,7 +26,7 @@ func Interpret(
 ) (*model.Value, error) {
 	switch expression := expression.(type) {
 	case string:
-		if regexp.MustCompile("^\\$\\(.+\\)$").MatchString(expression) {
+		if regexp.MustCompile(`^\$\(.+\)$`).MatchString(expression) {
 			var opts *model.ReferenceOpts
 			if createIfNotExist {
 				opts = &model.ReferenceOpts{
@@ -42,14 +41,14 @@ func Interpret(
 				opts,
 			)
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
+				return nil, fmt.Errorf("unable to interpret %+v to dir: %w", expression, err)
 			}
 
 			result, err := coerce.ToDir(value, scratchDir)
 			if err != nil {
-				err = errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
+				return nil, fmt.Errorf("unable to interpret %+v to dir: %w", expression, err)
 			}
-			return result, err
+			return result, nil
 
 		}
 	}
@@ -59,12 +58,12 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to dir: %w", expression, err)
 	}
 
 	result, err := coerce.ToDir(&value, scratchDir)
 	if err != nil {
-		err = errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to dir", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to dir: %w", expression, err)
 	}
 	return result, err
 }

--- a/sdks/go/opspec/interpreter/file/interpret.go
+++ b/sdks/go/opspec/interpreter/file/interpret.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
-	"github.com/pkg/errors"
 
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -29,7 +28,7 @@ func Interpret(
 ) (*model.Value, error) {
 	expressionAsString, expressionIsString := expression.(string)
 
-	if expressionIsString && regexp.MustCompile("^\\$\\(.+\\)$").MatchString(expressionAsString) {
+	if expressionIsString && regexp.MustCompile(`^\$\(.+\)$`).MatchString(expressionAsString) {
 		var opts *model.ReferenceOpts
 		if createIfNotExist {
 			opts = &model.ReferenceOpts{
@@ -44,7 +43,7 @@ func Interpret(
 			opts,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to file", expression))
+			return nil, fmt.Errorf("unable to interpret %+v to file: %w", expression, err)
 		}
 		return coerce.ToFile(value, scratchDir)
 	}
@@ -54,7 +53,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to file", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to file: %w", expression, err)
 	}
 
 	return coerce.ToFile(&value, scratchDir)

--- a/sdks/go/opspec/interpreter/interpolater/interpolate_test.go
+++ b/sdks/go/opspec/interpreter/interpolater/interpolate_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data"
 	"github.com/opctl/opctl/sdks/go/data/fs"
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 var _ = Context("Interpolate", func() {
@@ -40,22 +39,22 @@ var _ = Context("Interpolate", func() {
 								Expected string
 							}{}
 							if err := yaml.Unmarshal(scenariosOpFileBytes, &scenarioOpFile); err != nil {
-								panic(errors.Wrap(err, "error unmarshalling scenario.yml for "+path))
+								panic(fmt.Errorf("error unmarshalling scenario.yml for %s: %w", path, err))
 							}
 
 							absPath, err := filepath.Abs(path)
 							if err != nil {
-								panic(errors.Wrap(err, "error getting absPath for "+path))
+								panic(fmt.Errorf("error getting absPath for %s: %w", path, err))
 							}
 
 							opHandle, err := data.Resolve(context.Background(), absPath, fsProvider)
 							if err != nil {
-								panic(errors.Wrap(err, "error getting opHandle for "+path))
+								panic(fmt.Errorf("error getting opHandle for %s: %w", path, err))
 							}
 
 							for _, scenario := range scenarioOpFile {
 								// add op dir to scope
-								if 0 == len(scenario.Scope) {
+								if len(scenario.Scope) == 0 {
 									scenario.Scope = map[string]*model.Value{}
 								}
 								scenario.Scope["/"] = &model.Value{Dir: opHandle.Path()}

--- a/sdks/go/opspec/interpreter/number/interpret.go
+++ b/sdks/go/opspec/interpreter/number/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a number value.
@@ -21,7 +20,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to number", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to number: %w", expression, err)
 	}
 
 	return coerce.ToNumber(&v)

--- a/sdks/go/opspec/interpreter/object/interpret.go
+++ b/sdks/go/opspec/interpreter/object/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to an object value.
@@ -21,7 +20,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to object", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to object: %w", expression, err)
 	}
 
 	return coerce.ToObject(&value)

--- a/sdks/go/opspec/interpreter/reference/direntry/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/direntry/interpret.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/model"
-	"github.com/pkg/errors"
 )
 
 // Interpret a dir entry ref i.e. refs of the form name/sub/file.ext
@@ -34,10 +33,10 @@ func Interpret(
 		return "", &model.Value{File: &valuePath}, nil
 	} else if opts != nil && os.IsNotExist(err) {
 
-		if "Dir" == *opts {
+		if *opts == "Dir" {
 			err := os.MkdirAll(valuePath, 0700)
 			if err != nil {
-				return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
+				return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 			}
 
 			return "", &model.Value{Dir: &valuePath}, nil
@@ -46,19 +45,19 @@ func Interpret(
 		// handle file ref
 		err := os.MkdirAll(filepath.Dir(valuePath), 0700)
 		if err != nil {
-			return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
+			return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 		}
 
 		file, err := os.Create(valuePath)
 		file.Close()
 		if err != nil {
-			return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
+			return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 		}
 
 		return "", &model.Value{File: &valuePath}, nil
 
 	}
 
-	return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v' as dir entry ref", ref))
+	return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 
 }

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/interpret.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/bracketed/item"
-	"github.com/pkg/errors"
 
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
 
@@ -31,7 +30,7 @@ func Interpret(
 
 	data, err := CoerceToArrayOrObject(data)
 	if err != nil {
-		return "", nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
+		return "", nil, fmt.Errorf("unable to interpret '%v': %w", ref, err)
 	}
 
 	identifier := ref[1:indexOfNextCloseBracket]
@@ -51,7 +50,7 @@ func Interpret(
 	property := (*data.Object)[identifier]
 	propertyValue, err := value.Construct(property)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "unable to interpret property")
+		return "", nil, fmt.Errorf("unable to interpret property: %w", err)
 	}
 	return refRemainder, propertyValue, nil
 }

--- a/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/bracketed/item/interpret.go
@@ -1,9 +1,10 @@
 package item
 
 import (
+	"fmt"
+
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an item from data via indexString.
@@ -14,13 +15,13 @@ func Interpret(
 ) (*model.Value, error) {
 	itemIndex, err := ParseIndex(indexString, *data.Array)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to interpret item")
+		return nil, fmt.Errorf("unable to interpret item: %w", err)
 	}
 
 	item := (*data.Array)[itemIndex]
 	itemValue, err := value.Construct(item)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to interpret item")
+		return nil, fmt.Errorf("unable to interpret item: %w", err)
 	}
 
 	return itemValue, nil

--- a/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/identifier/unbracketed/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference/identifier/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an unbracketed identifier from ref as determined by unbracketed/parse.go
@@ -18,7 +17,7 @@ func Interpret(
 
 	dataAsObject, err := coerce.ToObject(data)
 	if err != nil {
-		return ref, nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
+		return ref, nil, fmt.Errorf("unable to interpret '%v': %w", ref, err)
 	}
 
 	identifier, refRemainder := Parse(ref)
@@ -30,7 +29,7 @@ func Interpret(
 
 	identifierValue, err := value.Construct(scopeValue)
 	if err != nil {
-		return ref, nil, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v'", ref))
+		return ref, nil, fmt.Errorf("unable to interpret '%v': %w", ref, err)
 	}
 
 	return refRemainder, identifierValue, nil

--- a/sdks/go/opspec/interpreter/str/interpret.go
+++ b/sdks/go/opspec/interpreter/str/interpret.go
@@ -6,7 +6,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/data/coerce"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/value"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a string value.
@@ -19,7 +18,7 @@ func Interpret(
 		scope,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("unable to interpret %+v to string", expression))
+		return nil, fmt.Errorf("unable to interpret %+v to string: %w", expression, err)
 	}
 
 	return coerce.ToString(&v)

--- a/sdks/go/opspec/interpreter/value/interpret.go
+++ b/sdks/go/opspec/interpreter/value/interpret.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opctl/opctl/sdks/go/opspec"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/interpolater"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/reference"
-	"github.com/pkg/errors"
 )
 
 // Interpret an expression to a value
@@ -46,13 +45,13 @@ func Interpret(
 				scope,
 			)
 			if err != nil {
-				return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v: %v' as object initializer property", propertyKeyExpression, propertyValueExpression))
+				return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property: %w", propertyKeyExpression, propertyValueExpression, err)
 			}
 
 			if propertyValue.File != nil {
 				fileBytes, err := ioutil.ReadFile(*propertyValue.File)
 				if err != nil {
-					return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%v: %v' as object initializer property", propertyKeyExpression, propertyValueExpression))
+					return model.Value{}, fmt.Errorf("unable to interpret '%v: %v' as object initializer property: %w", propertyKeyExpression, propertyValueExpression, err)
 				}
 
 				value[propertyKey] = string(fileBytes)
@@ -81,7 +80,7 @@ func Interpret(
 				scope,
 			)
 			if err != nil {
-				return model.Value{}, errors.Wrap(err, fmt.Sprintf("unable to interpret '%+v' as array initializer item", itemExpression))
+				return model.Value{}, fmt.Errorf("unable to interpret '%+v' as array initializer item: %w", itemExpression, err)
 			}
 			value = append(value, itemValue)
 		}

--- a/sdks/go/opspec/list.go
+++ b/sdks/go/opspec/list.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/opfile"
-	"github.com/pkg/errors"
 )
 
 // List ops recursively within a directory, returning discovered op files by path.
@@ -28,20 +27,20 @@ func List(
 
 			opFileReader, err := dirHandle.GetContent(ctx, content.Path)
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error opening %s%s", dirHandle.Ref(), content.Path))
+				return nil, fmt.Errorf("error opening %s%s: %w", dirHandle.Ref(), content.Path, err)
 			}
 
 			opFileBytes, err := ioutil.ReadAll(opFileReader)
 			opFileReader.Close()
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error reading %s%s", dirHandle.Ref(), content.Path))
+				return nil, fmt.Errorf("error reading %s%s: %w", dirHandle.Ref(), content.Path, err)
 			}
 
 			opFile, err := opfile.Unmarshal(
 				opFileBytes,
 			)
 			if err != nil {
-				return nil, errors.Wrap(err, fmt.Sprintf("error unmarshalling %s%s", dirHandle.Ref(), content.Path))
+				return nil, fmt.Errorf("error unmarshalling %s%s: %w", dirHandle.Ref(), content.Path, err)
 			}
 
 			opsByPath[filepath.Dir(content.Path)] = opFile

--- a/sdks/go/opspec/opfile/unmarshal_test.go
+++ b/sdks/go/opspec/opfile/unmarshal_test.go
@@ -66,7 +66,7 @@ var _ = Context("Unmarshal", func() {
 			/* assert */
 			Expect(actualErr).To(BeNil())
 
-			// compare contents via JSON; otherwise we encounter pointer inequalities
+			// compare as JSON; otherwise we encounter pointer inequalities
 			actualBytes, err := json.Marshal(actualOpFile)
 			if err != nil {
 				panic(err)

--- a/sdks/go/opspec/validate_test.go
+++ b/sdks/go/opspec/validate_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ghodss/yaml"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 var _ = Context("Validate", func() {
@@ -37,7 +36,7 @@ var _ = Context("Validate", func() {
 
 							description := fmt.Sprintf("scenario '%v'", path)
 							if err := yaml.Unmarshal(scenariosOpFileBytes, &scenarioOpFile); err != nil {
-								panic(errors.Wrap(err, "error unmarshalling "+description))
+								panic(fmt.Errorf("error unmarshalling %s: %w", description, err))
 							}
 
 							for _, scenario := range scenarioOpFile {


### PR DESCRIPTION
Why?
- github.com/pkg/errors [is in maintenance mode](https://github.com/pkg/errors#roadmap)
- using native go errors functionality [is more idiomatic in golang](https://blog.golang.org/go1.13-errors#TOC_5.)
- removes a 3rd party dep