### PR TITLE
Live progress & log line prefixes from opctl run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ accordance with
 
 ### Added
 
+- When running an op via opctl run, display progress via a live call graph
+- When running an op via opctl run, prefix log lines emitted by workloads with their op id & ref
 - Basic support for sending local files and directories to remote nodes when using the API client
 - [Allow defining description on call graph nodes](https://github.com/opctl/opctl/issues/900)
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opctl/opctl/cli/internal/nodeprovider/local"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec"
+	"golang.org/x/term"
 )
 
 var testModeEnvVar = "OPCTL_TEST_MODE"
@@ -278,6 +279,7 @@ func newCli(
 	cli.Command("run", "Start and wait on an op", func(runCmd *mow.Cmd) {
 		args := runCmd.StringsOpt("a", []string{}, "Explicitly pass args to op in format `-a NAME1=VALUE1 -a NAME2=VALUE2`")
 		argFile := runCmd.StringOpt("arg-file", filepath.Join(opspec.DotOpspecDirName, "args.yml"), "Read in a file of args in yml format")
+		noProgress := runCmd.BoolOpt("no-progress", !term.IsTerminal(int(os.Stdout.Fd())), "Disable live call graph for the op")
 		opRef := runCmd.StringArg("OP_REF", "", "Op reference (either `relative/path`, `/absolute/path`, `host/path/repo#tag`, or `host/path/repo#tag/path`)")
 
 		runCmd.Action = func() {
@@ -291,6 +293,7 @@ func newCli(
 					*args,
 					*argFile,
 					*opRef,
+					*noProgress,
 				),
 			)
 		}

--- a/cli/internal/clicolorer/cliColorer.go
+++ b/cli/internal/clicolorer/cliColorer.go
@@ -26,6 +26,8 @@ type CliColorer interface {
 		s string,
 	) string
 
+	Muted(s string) string
+
 	// success colors
 	Success(s string) string
 }
@@ -43,11 +45,15 @@ func New() CliColorer {
 	successCliColorer := color.New(color.FgHiGreen, color.Bold)
 	successCliColorer.EnableColor()
 
+	mutedCliColorer := color.New(color.Faint)
+	mutedCliColorer.EnableColor()
+
 	return &cliColorer{
 		attentionCliColorer: attentionCliColorer,
 		errorCliColorer:     errorCliColorer,
 		infoCliColorer:      infoCliColorer,
 		successCliColorer:   successCliColorer,
+		mutedCliColorer:     mutedCliColorer,
 	}
 }
 
@@ -56,6 +62,7 @@ type cliColorer struct {
 	errorCliColorer     *color.Color
 	infoCliColorer      *color.Color
 	successCliColorer   *color.Color
+	mutedCliColorer     *color.Color
 }
 
 func (this *cliColorer) DisableColor() {
@@ -87,4 +94,8 @@ func (this cliColorer) Success(
 	s string,
 ) string {
 	return this.successCliColorer.SprintFunc()(s)
+}
+
+func (this cliColorer) Muted(s string) string {
+	return this.mutedCliColorer.SprintFunc()(s)
 }

--- a/cli/internal/clicolorer/fakes/cliColorer.go
+++ b/cli/internal/clicolorer/fakes/cliColorer.go
@@ -45,6 +45,17 @@ type FakeCliColorer struct {
 	infoReturnsOnCall map[int]struct {
 		result1 string
 	}
+	MutedStub        func(string) string
+	mutedMutex       sync.RWMutex
+	mutedArgsForCall []struct {
+		arg1 string
+	}
+	mutedReturns struct {
+		result1 string
+	}
+	mutedReturnsOnCall map[int]struct {
+		result1 string
+	}
 	SuccessStub        func(string) string
 	successMutex       sync.RWMutex
 	successArgsForCall []struct {
@@ -263,6 +274,66 @@ func (fake *FakeCliColorer) InfoReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *FakeCliColorer) Muted(arg1 string) string {
+	fake.mutedMutex.Lock()
+	ret, specificReturn := fake.mutedReturnsOnCall[len(fake.mutedArgsForCall)]
+	fake.mutedArgsForCall = append(fake.mutedArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Muted", []interface{}{arg1})
+	fake.mutedMutex.Unlock()
+	if fake.MutedStub != nil {
+		return fake.MutedStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.mutedReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCliColorer) MutedCallCount() int {
+	fake.mutedMutex.RLock()
+	defer fake.mutedMutex.RUnlock()
+	return len(fake.mutedArgsForCall)
+}
+
+func (fake *FakeCliColorer) MutedCalls(stub func(string) string) {
+	fake.mutedMutex.Lock()
+	defer fake.mutedMutex.Unlock()
+	fake.MutedStub = stub
+}
+
+func (fake *FakeCliColorer) MutedArgsForCall(i int) string {
+	fake.mutedMutex.RLock()
+	defer fake.mutedMutex.RUnlock()
+	argsForCall := fake.mutedArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCliColorer) MutedReturns(result1 string) {
+	fake.mutedMutex.Lock()
+	defer fake.mutedMutex.Unlock()
+	fake.MutedStub = nil
+	fake.mutedReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeCliColorer) MutedReturnsOnCall(i int, result1 string) {
+	fake.mutedMutex.Lock()
+	defer fake.mutedMutex.Unlock()
+	fake.MutedStub = nil
+	if fake.mutedReturnsOnCall == nil {
+		fake.mutedReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.mutedReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
 func (fake *FakeCliColorer) Success(arg1 string) string {
 	fake.successMutex.Lock()
 	ret, specificReturn := fake.successReturnsOnCall[len(fake.successArgsForCall)]
@@ -334,6 +405,8 @@ func (fake *FakeCliColorer) Invocations() map[string][][]interface{} {
 	defer fake.errorMutex.RUnlock()
 	fake.infoMutex.RLock()
 	defer fake.infoMutex.RUnlock()
+	fake.mutedMutex.RLock()
+	defer fake.mutedMutex.RUnlock()
 	fake.successMutex.RLock()
 	defer fake.successMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/cli/internal/clioutput/cliOutput_test.go
+++ b/cli/internal/clioutput/cliOutput_test.go
@@ -27,11 +27,7 @@ var _ = Context("output", func() {
 		providedFormat := "dummyFormat %v %v"
 		It("should call stdWriter w/ expected args", func() {
 			/* arrange */
-			expectedWriteArg := []byte(
-				fmt.Sprintln(
-					_cliColorer.Attention(providedFormat),
-				),
-			)
+			expectedWriteArg := fmt.Sprintln(_cliColorer.Attention(providedFormat))
 
 			fakeStdWriter := new(fakeWriter)
 			objectUnderTest := New(
@@ -44,7 +40,7 @@ var _ = Context("output", func() {
 			objectUnderTest.Attention(providedFormat)
 
 			/* assert */
-			Expect(fakeStdWriter.WriteArgsForCall(0)).
+			Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 				To(Equal(expectedWriteArg))
 		})
 	})
@@ -52,11 +48,7 @@ var _ = Context("output", func() {
 		providedFormat := "dummyFormat %v %v"
 		It("should call stdWriter w/ expected args", func() {
 			/* arrange */
-			expectedWriteArg := []byte(
-				fmt.Sprintln(
-					_cliColorer.Error(providedFormat),
-				),
-			)
+			expectedWriteArg := fmt.Sprintln(_cliColorer.Error(providedFormat))
 
 			fakeErrWriter := new(fakeWriter)
 			objectUnderTest := New(
@@ -69,7 +61,7 @@ var _ = Context("output", func() {
 			objectUnderTest.Warning(providedFormat)
 
 			/* assert */
-			Expect(fakeErrWriter.WriteArgsForCall(0)).
+			Expect(string(fakeErrWriter.WriteArgsForCall(0))).
 				To(Equal(expectedWriteArg))
 		})
 	})
@@ -77,11 +69,7 @@ var _ = Context("output", func() {
 		providedFormat := "dummyFormat %v %v"
 		It("should call errWriter w/ expected args", func() {
 			/* arrange */
-			expectedWriteArg := []byte(
-				fmt.Sprintln(
-					_cliColorer.Error(providedFormat),
-				),
-			)
+			expectedWriteArg := fmt.Sprintln(_cliColorer.Error(providedFormat))
 
 			fakeErrWriter := new(fakeWriter)
 			objectUnderTest := New(
@@ -94,7 +82,7 @@ var _ = Context("output", func() {
 			objectUnderTest.Error(providedFormat)
 
 			/* assert */
-			Expect(fakeErrWriter.WriteArgsForCall(0)).
+			Expect(string(fakeErrWriter.WriteArgsForCall(0))).
 				To(Equal(expectedWriteArg))
 		})
 	})
@@ -104,11 +92,12 @@ var _ = Context("output", func() {
 				/* arrange */
 				providedEvent := &model.Event{
 					ContainerStdErrWrittenTo: &model.ContainerStdErrWrittenTo{
-						Data: []byte("dummyData"),
+						ContainerID: "acontainerid",
+						Data:        []byte("dummyData"),
 					},
 					Timestamp: time.Now(),
 				}
-				expectedWriteArg := []byte(string(providedEvent.ContainerStdErrWrittenTo.Data))
+				expectedWriteArg := "\x1b[2m[acontain]\x1b[0m " + string(providedEvent.ContainerStdErrWrittenTo.Data)
 
 				fakeErrWriter := new(fakeWriter)
 				objectUnderTest := New(
@@ -121,7 +110,7 @@ var _ = Context("output", func() {
 				objectUnderTest.Event(providedEvent)
 
 				/* assert */
-				Expect(fakeErrWriter.WriteArgsForCall(0)).
+				Expect(string(fakeErrWriter.WriteArgsForCall(0))).
 					To(Equal(expectedWriteArg))
 			})
 		})
@@ -130,11 +119,12 @@ var _ = Context("output", func() {
 				/* arrange */
 				providedEvent := &model.Event{
 					ContainerStdOutWrittenTo: &model.ContainerStdOutWrittenTo{
-						Data: []byte("dummyData"),
+						ContainerID: "acontainerid",
+						Data:        []byte("dummyData"),
 					},
 					Timestamp: time.Now(),
 				}
-				expectedWriteArg := []byte(string(providedEvent.ContainerStdOutWrittenTo.Data))
+				expectedWriteArg := "\x1b[2m[acontain]\x1b[0m " + string(providedEvent.ContainerStdOutWrittenTo.Data)
 
 				fakeStdWriter := new(fakeWriter)
 				objectUnderTest := New(
@@ -147,7 +137,7 @@ var _ = Context("output", func() {
 				objectUnderTest.Event(providedEvent)
 
 				/* assert */
-				Expect(fakeStdWriter.WriteArgsForCall(0)).
+				Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 					To(Equal(expectedWriteArg))
 			})
 		})
@@ -164,27 +154,14 @@ var _ = Context("output", func() {
 										Ref: &imageRef,
 									},
 								},
-								ID: "ID",
+								ID: "acontainerID",
 							},
 							Outcome: model.OpOutcomeSucceeded,
 							Ref:     "ref",
 						},
 						Timestamp: time.Now(),
 					}
-					expectedWriteArg := []byte(
-						fmt.Sprintln(
-							_cliColorer.Success(
-								fmt.Sprintf(
-									"ContainerExited Id='%v'%v Outcome='%v'%v Timestamp='%v'\n",
-									providedEvent.CallEnded.Call.ID,
-									fmt.Sprintf(" ImageRef='%v'", imageRef),
-									providedEvent.CallEnded.Outcome,
-									"",
-									providedEvent.Timestamp.Format(time.RFC3339),
-								),
-							),
-						),
-					)
+					expectedWriteArg := "\x1b[2m[acontain ref]\x1b[0m \x1b[92;1mimageRef exited\x1b[0m\n"
 
 					fakeStdWriter := new(fakeWriter)
 					objectUnderTest := New(
@@ -197,7 +174,7 @@ var _ = Context("output", func() {
 					objectUnderTest.Event(providedEvent)
 
 					/* assert */
-					Expect(fakeStdWriter.WriteArgsForCall(0)).
+					Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 						To(Equal(expectedWriteArg))
 				})
 			})
@@ -209,7 +186,7 @@ var _ = Context("output", func() {
 						providedEvent := &model.Event{
 							CallEnded: &model.CallEnded{
 								Call: model.Call{
-									ID: "ID",
+									ID: "thisisacallID",
 									Op: &model.OpCall{
 										BaseCall: model.BaseCall{
 											OpPath: "opPath",
@@ -224,20 +201,7 @@ var _ = Context("output", func() {
 							},
 							Timestamp: time.Now(),
 						}
-						expectedWriteArg := []byte(
-							fmt.Sprintln(
-								_cliColorer.Error(
-									fmt.Sprintf(
-										"OpEnded Id='%v' OpRef='%v' Outcome='%v'%v Timestamp='%v'\n",
-										providedEvent.CallEnded.Call.ID,
-										providedEvent.CallEnded.Call.Op.OpPath,
-										providedEvent.CallEnded.Outcome,
-										fmt.Sprintf(" Error='%v'", providedEvent.CallEnded.Error.Message),
-										providedEvent.Timestamp.Format(time.RFC3339),
-									),
-								),
-							),
-						)
+						expectedWriteArg := "\x1b[2m[thisisac opPath]\x1b[0m \x1b[91;1mop failed\x1b[0m\x1b[91;1m:\x1b[0m message\n"
 
 						fakeErrWriter := new(fakeWriter)
 						objectUnderTest := New(
@@ -250,7 +214,7 @@ var _ = Context("output", func() {
 						objectUnderTest.Event(providedEvent)
 
 						/* assert */
-						Expect(fakeErrWriter.WriteArgsForCall(0)).
+						Expect(string(fakeErrWriter.WriteArgsForCall(0))).
 							To(Equal(expectedWriteArg))
 					})
 				})
@@ -260,7 +224,7 @@ var _ = Context("output", func() {
 						providedEvent := &model.Event{
 							CallEnded: &model.CallEnded{
 								Call: model.Call{
-									ID: "ID",
+									ID: "thisisacallID",
 									Op: &model.OpCall{
 										BaseCall: model.BaseCall{
 											OpPath: "opPath",
@@ -272,19 +236,7 @@ var _ = Context("output", func() {
 							},
 							Timestamp: time.Now(),
 						}
-						expectedWriteArg := []byte(
-							fmt.Sprintln(
-								_cliColorer.Success(
-									fmt.Sprintf(
-										"OpEnded Id='%v' OpRef='%v' Outcome='%v' Timestamp='%v'\n",
-										providedEvent.CallEnded.Call.ID,
-										providedEvent.CallEnded.Call.Op.OpPath,
-										providedEvent.CallEnded.Outcome,
-										providedEvent.Timestamp.Format(time.RFC3339),
-									),
-								),
-							),
-						)
+						expectedWriteArg := "\x1b[2m[thisisac opPath]\x1b[0m \x1b[92;1mop succeeded\x1b[0m\n"
 
 						fakeStdWriter := new(fakeWriter)
 						objectUnderTest := New(
@@ -297,7 +249,7 @@ var _ = Context("output", func() {
 						objectUnderTest.Event(providedEvent)
 
 						/* assert */
-						Expect(fakeStdWriter.WriteArgsForCall(0)).
+						Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 							To(Equal(expectedWriteArg))
 					})
 				})
@@ -307,7 +259,7 @@ var _ = Context("output", func() {
 						providedEvent := &model.Event{
 							CallEnded: &model.CallEnded{
 								Call: model.Call{
-									ID: "ID",
+									ID: "thisisacallID",
 									Op: &model.OpCall{
 										BaseCall: model.BaseCall{
 											OpPath: "opPath",
@@ -319,19 +271,7 @@ var _ = Context("output", func() {
 							},
 							Timestamp: time.Now(),
 						}
-						expectedWriteArg := []byte(
-							fmt.Sprintln(
-								_cliColorer.Info(
-									fmt.Sprintf(
-										"OpEnded Id='%v' OpRef='%v' Outcome='%v' Timestamp='%v'\n",
-										providedEvent.CallEnded.Call.ID,
-										providedEvent.CallEnded.Call.Op.OpPath,
-										providedEvent.CallEnded.Outcome,
-										providedEvent.Timestamp.Format(time.RFC3339),
-									),
-								),
-							),
-						)
+						expectedWriteArg := "\x1b[2m[thisisac opPath]\x1b[0m \x1b[96;1mop killed\x1b[0m\n"
 
 						fakeStdWriter := new(fakeWriter)
 						objectUnderTest := New(
@@ -344,7 +284,7 @@ var _ = Context("output", func() {
 						objectUnderTest.Event(providedEvent)
 
 						/* assert */
-						Expect(fakeStdWriter.WriteArgsForCall(0)).
+						Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 							To(Equal(expectedWriteArg))
 					})
 				})
@@ -355,7 +295,12 @@ var _ = Context("output", func() {
 					providedEvent := &model.Event{
 						CallEnded: &model.CallEnded{
 							Call: model.Call{
-								ID: "ID",
+								ID: "thisisacallID",
+								Op: &model.OpCall{
+									BaseCall: model.BaseCall{
+										OpPath: "opPath",
+									},
+								},
 							},
 							Error: &model.CallEndedError{
 								Message: "message",
@@ -364,19 +309,7 @@ var _ = Context("output", func() {
 						},
 						Timestamp: time.Now(),
 					}
-					expectedWriteArg := []byte(
-						fmt.Sprintln(
-							_cliColorer.Error(
-								fmt.Sprintf(
-									"Error='%v' Id='%v' OpRef='%v' Timestamp='%v'\n",
-									providedEvent.CallEnded.Error.Message,
-									providedEvent.CallEnded.Call.ID,
-									providedEvent.CallEnded.Ref,
-									providedEvent.Timestamp.Format(time.RFC3339),
-								),
-							),
-						),
-					)
+					expectedWriteArg := "\x1b[2m[thisisac opPath]\x1b[0m \x1b[91;1mop failed\x1b[0m\x1b[91;1m:\x1b[0m message\n"
 
 					fakeErrWriter := new(fakeWriter)
 					objectUnderTest := New(
@@ -389,7 +322,7 @@ var _ = Context("output", func() {
 					objectUnderTest.Event(providedEvent)
 
 					/* assert */
-					Expect(fakeErrWriter.WriteArgsForCall(0)).
+					Expect(string(fakeErrWriter.WriteArgsForCall(0))).
 						To(Equal(expectedWriteArg))
 				})
 			})
@@ -402,6 +335,7 @@ var _ = Context("output", func() {
 					providedEvent := &model.Event{
 						CallStarted: &model.CallStarted{
 							Call: model.Call{
+								ID: "thisisacallID",
 								Container: &model.ContainerCall{
 									Image: &model.ContainerCallImage{
 										Ref: &imageRef,
@@ -412,19 +346,7 @@ var _ = Context("output", func() {
 						},
 						Timestamp: time.Now(),
 					}
-					expectedWriteArg := []byte(
-						fmt.Sprintln(
-							_cliColorer.Info(
-								fmt.Sprintf(
-									"ContainerStarted Id='%v' OpRef='%v' ImageRef='%v' Timestamp='%v'\n",
-									providedEvent.CallStarted.Call.ID,
-									providedEvent.CallStarted.Ref,
-									imageRef,
-									providedEvent.Timestamp.Format(time.RFC3339),
-								),
-							),
-						),
-					)
+					expectedWriteArg := "\x1b[2m[thisisac ref]\x1b[0m \x1b[96;1mstarted imageRef\x1b[0m\n"
 
 					fakeStdWriter := new(fakeWriter)
 					objectUnderTest := New(
@@ -437,7 +359,7 @@ var _ = Context("output", func() {
 					objectUnderTest.Event(providedEvent)
 
 					/* assert */
-					Expect(fakeStdWriter.WriteArgsForCall(0)).
+					Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 						To(Equal(expectedWriteArg))
 				})
 			})
@@ -447,7 +369,7 @@ var _ = Context("output", func() {
 					providedEvent := &model.Event{
 						CallStarted: &model.CallStarted{
 							Call: model.Call{
-								ID: "ID",
+								ID: "thisisacallID",
 								Op: &model.OpCall{
 									BaseCall: model.BaseCall{
 										OpPath: "opPath",
@@ -458,18 +380,7 @@ var _ = Context("output", func() {
 						},
 						Timestamp: time.Now(),
 					}
-					expectedWriteArg := []byte(
-						fmt.Sprintln(
-							_cliColorer.Info(
-								fmt.Sprintf(
-									"OpStarted Id='%v' OpRef='%v' Timestamp='%v'\n",
-									providedEvent.CallStarted.Call.ID,
-									providedEvent.CallStarted.Call.Op.OpPath,
-									providedEvent.Timestamp.Format(time.RFC3339),
-								),
-							),
-						),
-					)
+					expectedWriteArg := "\x1b[2m[thisisac opPath]\x1b[0m \x1b[96;1mstarted op\x1b[0m\n"
 
 					fakeStdWriter := new(fakeWriter)
 					objectUnderTest := New(
@@ -482,46 +393,17 @@ var _ = Context("output", func() {
 					objectUnderTest.Event(providedEvent)
 
 					/* assert */
-					Expect(fakeStdWriter.WriteArgsForCall(0)).
+					Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 						To(Equal(expectedWriteArg))
 				})
 			})
-		})
-	})
-	Context("Info", func() {
-		providedFormat := "dummyFormat %v %v"
-		It("should call stdWriter w/ expected args", func() {
-			/* arrange */
-			expectedWriteArg := []byte(
-				fmt.Sprintln(
-					_cliColorer.Info(providedFormat),
-				),
-			)
-
-			fakeStdWriter := new(fakeWriter)
-			objectUnderTest := New(
-				_cliColorer,
-				new(fakeWriter),
-				fakeStdWriter,
-			)
-
-			/* act */
-			objectUnderTest.Info(providedFormat)
-
-			/* assert */
-			Expect(fakeStdWriter.WriteArgsForCall(0)).
-				To(Equal(expectedWriteArg))
 		})
 	})
 	Context("Success", func() {
 		providedFormat := "dummyFormat %v %v"
 		It("should call stdWriter w/ expected args", func() {
 			/* arrange */
-			expectedWriteArg := []byte(
-				fmt.Sprintln(
-					_cliColorer.Success(providedFormat),
-				),
-			)
+			expectedWriteArg := fmt.Sprintln(_cliColorer.Success(providedFormat))
 
 			fakeStdWriter := new(fakeWriter)
 			objectUnderTest := New(
@@ -534,7 +416,7 @@ var _ = Context("output", func() {
 			objectUnderTest.Success(providedFormat)
 
 			/* assert */
-			Expect(fakeStdWriter.WriteArgsForCall(0)).
+			Expect(string(fakeStdWriter.WriteArgsForCall(0))).
 				To(Equal(expectedWriteArg))
 		})
 	})

--- a/cli/internal/clioutput/formatOpRef.go
+++ b/cli/internal/clioutput/formatOpRef.go
@@ -1,0 +1,33 @@
+package clioutput
+
+import (
+	"os"
+	"path"
+	"strings"
+)
+
+// FormatOpRef gives a more appropriate description of an op's reference
+// Local ops will be formatted as paths relative to the working directory or
+// home directory
+func FormatOpRef(opRef string) string {
+	if path.IsAbs(opRef) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return opRef
+		}
+
+		if strings.HasPrefix(opRef, cwd) {
+			return "." + opRef[len(cwd):]
+		}
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return opRef
+		}
+
+		if strings.HasPrefix(opRef, home) {
+			return "~" + opRef[len(home):]
+		}
+	}
+	return opRef
+}

--- a/cli/internal/cliparamsatisfier/cliParamSatisfier.go
+++ b/cli/internal/cliparamsatisfier/cliParamSatisfier.go
@@ -35,7 +35,7 @@ func New(
 
 	return &_CLIParamSatisfier{
 		cliOutput:       cliOutput,
-		InputSrcFactory: newInputSrcFactory(),
+		InputSrcFactory: newInputSrcFactory(cliOutput),
 	}
 }
 
@@ -59,10 +59,7 @@ func (cps _CLIParamSatisfier) Satisfy(
 
 			rawArg, ok := inputSourcer.Source(paramName)
 			if !ok {
-				return nil, fmt.Errorf(`
--
-  Prompt for '%v' failed; running in non-interactive terminal
--`, paramName)
+				return nil, fmt.Errorf("failed to get input '%s'", paramName)
 			}
 
 			switch {
@@ -190,15 +187,14 @@ func (this _CLIParamSatisfier) notifyOfArgErrors(
 ) {
 	messageBuffer := bytes.NewBufferString(
 		fmt.Sprintf(`
--
-  %v invalid; provide valid value to proceed.
-  Error(s):`, paramName),
+%v is invalid, provide valid value to proceed
+error:`, paramName),
 	)
 
 	for _, validationError := range errors {
 		messageBuffer.WriteString(
 			fmt.Sprintf(`
-	- %v`,
+- %v`,
 				validationError.Error(),
 			),
 		)
@@ -206,8 +202,7 @@ func (this _CLIParamSatisfier) notifyOfArgErrors(
 
 	messageBuffer.WriteString(
 		fmt.Sprintf(`
-%v
--`,
+%v`,
 			messageBuffer.String(),
 		),
 	)

--- a/cli/internal/cliparamsatisfier/cliParamSatisfier_test.go
+++ b/cli/internal/cliparamsatisfier/cliParamSatisfier_test.go
@@ -3,6 +3,7 @@ package cliparamsatisfier
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -21,11 +22,14 @@ var _ = Context("parameterSatisfier", func() {
 	if err != nil {
 		panic(err)
 	}
+
+	cliOutput := clioutput.New(clicolorer.New(), ioutil.Discard, ioutil.Discard)
+
 	Context("New", func() {
 		It("should return truthy result", func() {
 			/* arrange/act */
 			actual := New(
-				clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+				cliOutput,
 			)
 
 			/* assert */
@@ -48,7 +52,7 @@ var _ = Context("parameterSatisfier", func() {
 			}
 
 			objectUnderTest := _CLIParamSatisfier{
-				cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+				cliOutput: cliOutput,
 			}
 
 			/* act */
@@ -91,7 +95,7 @@ var _ = Context("parameterSatisfier", func() {
 					providedInputSourcer.SourceReturns(&valueString, true)
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */
@@ -123,7 +127,7 @@ var _ = Context("parameterSatisfier", func() {
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */
@@ -159,7 +163,7 @@ var _ = Context("parameterSatisfier", func() {
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */
@@ -195,7 +199,7 @@ var _ = Context("parameterSatisfier", func() {
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */
@@ -227,7 +231,7 @@ var _ = Context("parameterSatisfier", func() {
 					}
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */
@@ -266,7 +270,7 @@ var _ = Context("parameterSatisfier", func() {
 					providedInputSourcer.SourceReturns(&valueString, true)
 
 					objectUnderTest := _CLIParamSatisfier{
-						cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+						cliOutput: cliOutput,
 					}
 
 					/* act */

--- a/cli/internal/cliparamsatisfier/inputSrcFactory.go
+++ b/cli/internal/cliparamsatisfier/inputSrcFactory.go
@@ -1,6 +1,7 @@
 package cliparamsatisfier
 
 import (
+	"github.com/opctl/opctl/cli/internal/clioutput"
 	"github.com/opctl/opctl/cli/internal/cliparamsatisfier/inputsrc"
 	"github.com/opctl/opctl/cli/internal/cliparamsatisfier/inputsrc/cliprompt"
 	"github.com/opctl/opctl/cli/internal/cliparamsatisfier/inputsrc/envvar"
@@ -31,16 +32,18 @@ type InputSrcFactory interface {
 	) (inputsrc.InputSrc, error)
 }
 
-func newInputSrcFactory() InputSrcFactory {
-	return _inputSrcFactory{}
+func newInputSrcFactory(cliOutput clioutput.CliOutput) InputSrcFactory {
+	return _inputSrcFactory{cliOutput: cliOutput}
 }
 
-type _inputSrcFactory struct{}
+type _inputSrcFactory struct {
+	cliOutput clioutput.CliOutput
+}
 
 func (is _inputSrcFactory) NewCliPromptInputSrc(
 	inputs map[string]*model.ParamSpec,
 ) inputsrc.InputSrc {
-	return cliprompt.New(inputs)
+	return cliprompt.New(is.cliOutput, inputs)
 }
 
 func (is _inputSrcFactory) NewEnvVarInputSrc() inputsrc.InputSrc {

--- a/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt.go
+++ b/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt.go
@@ -2,9 +2,7 @@ package cliprompt
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/opctl/opctl/cli/internal/clicolorer"
 	"github.com/opctl/opctl/cli/internal/clioutput"
 	"github.com/opctl/opctl/cli/internal/cliparamsatisfier/inputsrc"
 	"github.com/opctl/opctl/sdks/go/model"
@@ -12,11 +10,12 @@ import (
 )
 
 func New(
+	cliOutput clioutput.CliOutput,
 	inputs map[string]*model.ParamSpec,
 ) inputsrc.InputSrc {
 	return cliPromptInputSrc{
 		inputs:    inputs,
-		cliOutput: clioutput.New(clicolorer.New(), os.Stderr, os.Stdout),
+		cliOutput: cliOutput,
 	}
 }
 

--- a/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt_test.go
+++ b/cli/internal/cliparamsatisfier/inputsrc/cliprompt/cliPrompt_test.go
@@ -1,12 +1,18 @@
 package cliprompt
 
 import (
+	"io/ioutil"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/cli/internal/clicolorer"
+	"github.com/opctl/opctl/cli/internal/clioutput"
 	"github.com/opctl/opctl/sdks/go/model"
 )
 
 var _ = Describe("cliPromptInputSrc", func() {
+	cliOutput := clioutput.New(clicolorer.New(), ioutil.Discard, ioutil.Discard)
+
 	Context("ReadString()", func() {
 		Context("inputs contains entry for inputName", func() {
 			Context("input already read", func() {
@@ -23,6 +29,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 					}
 
 					objectUnderTest := New(
+						cliOutput,
 						map[string]*model.ParamSpec{inputName: param},
 					)
 
@@ -49,6 +56,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 						}
 
 						objectUnderTest := New(
+							cliOutput,
 							map[string]*model.ParamSpec{inputName: param},
 						)
 
@@ -70,6 +78,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 						}
 
 						objectUnderTest := New(
+							cliOutput,
 							map[string]*model.ParamSpec{inputName: param},
 						)
 
@@ -92,6 +101,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 							}
 
 							objectUnderTest := New(
+								cliOutput,
 								map[string]*model.ParamSpec{inputName: param},
 							)
 
@@ -115,6 +125,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 							}
 
 							objectUnderTest := New(
+								cliOutput,
 								map[string]*model.ParamSpec{inputName: param},
 							)
 
@@ -137,6 +148,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 						}
 
 						objectUnderTest := New(
+							cliOutput,
 							map[string]*model.ParamSpec{inputName: param},
 						)
 
@@ -158,6 +170,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 						}
 
 						objectUnderTest := New(
+							cliOutput,
 							map[string]*model.ParamSpec{inputName: param},
 						)
 
@@ -179,6 +192,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 						}
 
 						objectUnderTest := New(
+							cliOutput,
 							map[string]*model.ParamSpec{inputName: param},
 						)
 
@@ -197,6 +211,7 @@ var _ = Describe("cliPromptInputSrc", func() {
 		It("should return expected result", func() {
 			/* arrange */
 			objectUnderTest := New(
+				cliOutput,
 				map[string]*model.ParamSpec{},
 			)
 

--- a/cli/internal/opgraph/callgraph.go
+++ b/cli/internal/opgraph/callgraph.go
@@ -1,0 +1,249 @@
+package opgraph
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opctl/opctl/cli/internal/clioutput"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+// CallGraph maintains a record of the current state of an op
+type CallGraph struct {
+	rootNode *callGraphNode
+	errors   []error
+}
+
+type callGraphNode struct {
+	call      *model.Call
+	startTime *time.Time
+	endTime   *time.Time
+	state     string
+	children  []*callGraphNode
+}
+
+func newCallGraphNode(call *model.Call, timestamp time.Time) *callGraphNode {
+	return &callGraphNode{
+		call:      call,
+		startTime: &timestamp,
+		children:  []*callGraphNode{},
+	}
+}
+
+var errNotFoundInGraph = errors.New("not found in graph")
+
+const skippedState = "skipped"
+
+func (n *callGraphNode) insert(call *model.Call, startTime time.Time, initialState string) error {
+	if call.ParentID == nil {
+		return fmt.Errorf("missing parent ID for %s", call.ID)
+	}
+	if n.call.ID == *call.ParentID {
+		node := newCallGraphNode(call, startTime)
+		node.state = initialState
+		n.children = append(n.children, node)
+		return nil
+	}
+	for _, child := range n.children {
+		err := child.insert(call, startTime, initialState)
+		if err == nil {
+			return nil
+		}
+	}
+	return errNotFoundInGraph
+}
+
+func (n *callGraphNode) find(call *model.Call) *callGraphNode {
+	if call.ID == n.call.ID {
+		return n
+	}
+	for _, child := range n.children {
+		if c := child.find(call); c != nil {
+			return c
+		}
+	}
+	return nil
+}
+
+func (n *callGraphNode) isLeaf() bool {
+	return len(n.children) == 0
+}
+
+func (n *callGraphNode) countChildren() int {
+	count := 0
+	for _, child := range n.children {
+		if child.isLeaf() {
+			count++
+		} else {
+			count += child.countChildren()
+		}
+	}
+	return count
+}
+
+func (n callGraphNode) String(loader LoadingSpinner, now time.Time, collapseCompleted bool) string {
+	var str strings.Builder
+
+	// Graph node indicator
+	if n.isLeaf() {
+		str.WriteString("◉")
+	} else {
+		str.WriteString("◎")
+	}
+
+	// Leading "status"
+	switch n.state {
+	case model.OpOutcomeSucceeded:
+		str.WriteString(success.Sprint(" ☑"))
+	case model.OpOutcomeFailed:
+		str.WriteString(failed.Sprint(" ⚠"))
+	case model.OpOutcomeKilled:
+		str.WriteString("️ ☒")
+	case skippedState:
+		str.WriteString(" ☐")
+	case "":
+		// only display loading spinner on leaf nodes
+		if n.isLeaf() {
+			str.WriteString(" " + loader.String())
+		}
+	default:
+		str.WriteString(n.state)
+	}
+
+	call := *n.call
+
+	// "Named" ops
+	if call.Name != nil {
+		str.WriteString(" " + highlighted.Sprint(*call.Name))
+	}
+
+	// Main node description
+	var desc string
+	if call.Container != nil {
+		desc = muted.Sprint(call.Container.ContainerID[:8]) + " "
+		if call.Container.Name != nil {
+			desc += highlighted.Sprint(*call.Container.Name)
+		} else {
+			desc += *call.Container.Image.Ref
+		}
+	} else if call.Op != nil {
+		desc = highlighted.Sprint(clioutput.FormatOpRef(call.Op.OpPath))
+	} else if call.Parallel != nil {
+		desc = "parallel"
+	} else if call.ParallelLoop != nil {
+		desc = "parallel loop"
+	} else if call.Serial != nil {
+		desc = "serial"
+	} else if call.SerialLoop != nil {
+		desc = "serial loop"
+	}
+
+	collapsed := n.state == model.OpOutcomeSucceeded && !n.isLeaf() && collapseCompleted
+
+	if call.If != nil {
+		str.WriteString(" if")
+		// this means it was skipped
+		if desc == "" {
+			str.WriteString(" " + muted.Sprint("skipped"))
+		} else {
+			str.WriteString("\n")
+			if n.isLeaf() || collapsed {
+				str.WriteString(" ")
+			} else {
+				str.WriteString("│")
+			}
+		}
+	}
+
+	if desc != "" {
+		str.WriteString(" " + desc)
+	}
+
+	// Time elapsed
+	if n.startTime != nil && n.state != skippedState {
+		if n.endTime != nil { // if done
+			str.WriteString(" " + n.endTime.Sub(*n.startTime).String())
+		} else if n.isLeaf() { // only display live time for leaf nodes, like loading spinner
+			// don't show milliseconds - they're not really understandable
+			str.WriteString(" " + now.Sub(*n.startTime).Round(time.Second).String())
+		}
+	}
+
+	// Add the command invoked by a container if it's not named
+	if call.Container != nil && call.Container.Name == nil && len(call.Container.Cmd) > 0 {
+		str.WriteString(" " + muted.Sprint(strings.ReplaceAll(strings.Join(call.Container.Cmd, " "), "\n", "\\n")))
+	}
+
+	// Collapsed nodes
+	if collapsed {
+		str.WriteString(" ")
+		childCount := n.countChildren()
+		if childCount == 1 {
+			str.WriteString(muted.Sprint("(1 child)"))
+		} else {
+			str.WriteString(muted.Sprintf("(%d children)", childCount))
+		}
+		return str.String()
+	}
+
+	// Children
+	childLen := len(n.children)
+	for i, child := range n.children {
+		childLines := strings.Split(child.String(loader, now, collapseCompleted), "\n")
+		for j, part := range childLines {
+			if j == 0 {
+				if i < childLen-1 {
+					str.WriteString(fmt.Sprintf("\n├─%s", part))
+				} else {
+					str.WriteString(fmt.Sprintf("\n└─%s", part))
+				}
+			} else if i < childLen-1 {
+				str.WriteString(fmt.Sprintf("\n│ %s", part))
+			} else {
+				str.WriteString(fmt.Sprintf("\n  %s", part))
+			}
+		}
+	}
+
+	return str.String()
+}
+
+// String returns a visual representation of the current state of the call graph
+func (g CallGraph) String(loader LoadingSpinner, now time.Time, collapseCompleted bool) string {
+	var str strings.Builder
+	if g.rootNode == nil {
+		return "Empty call graph"
+	}
+	str.WriteString(g.rootNode.String(loader, now, collapseCompleted))
+	for _, err := range g.errors {
+		str.WriteString("\n" + warning.Sprint("⚠️  ") + err.Error())
+	}
+	return str.String()
+}
+
+// HandleEvent accepts an opctl event and updates the call graph appropriately
+func (g *CallGraph) HandleEvent(event *model.Event) error {
+	if event.CallStarted != nil {
+		if event.CallStarted.Call.ParentID == nil {
+			if g.rootNode == nil {
+				g.rootNode = newCallGraphNode(&event.CallStarted.Call, event.Timestamp)
+				return nil
+			}
+			return errors.New("parent node already set")
+		}
+		return g.rootNode.insert(&event.CallStarted.Call, event.Timestamp, "")
+	} else if event.CallEnded != nil {
+		if g.rootNode == nil {
+			return nil
+		}
+		node := g.rootNode.find(&event.CallEnded.Call)
+		if node == nil {
+			return g.rootNode.insert(&event.CallEnded.Call, event.Timestamp, skippedState)
+		}
+		node.endTime = &event.Timestamp
+		node.state = event.CallEnded.Outcome
+	}
+	return nil
+}

--- a/cli/internal/opgraph/callgraph_test.go
+++ b/cli/internal/opgraph/callgraph_test.go
@@ -1,0 +1,431 @@
+package opgraph
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+type noopOpFormatter struct{}
+
+func (noopOpFormatter) FormatOpRef(opRef string) string {
+	return opRef
+}
+
+func TestCallGraph(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	/* arrange */
+	timestamp, err := time.Parse("Jan 2, 2006 at 3:04pm (MST)", "Feb 4, 2014 at 6:05pm (PST)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectUnderTest := CallGraph{}
+	parentID := "parentID"
+	child1ID := "child1ID"
+	child2ID := "child2ID"
+	child3ID := "child3ID"
+	containerRef := "containerRef"
+	child1child1ID := "child1child1Id"
+	child2If := false
+	child3If := true
+
+	g.Expect(objectUnderTest.String(
+		StaticLoadingSpinner{},
+		timestamp.Add(time.Second*60),
+		true,
+	)).To(Equal("Empty call graph"))
+
+	/* act */
+	// this is the root event
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID: parentID,
+				Op: &model.OpCall{
+					BaseCall: model.BaseCall{
+						OpPath: "oppath",
+					},
+					OpID: "firstopid",
+				},
+			},
+		},
+		Timestamp: timestamp,
+	})
+	// first child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child1ID,
+				ParentID: &parentID,
+				Op: &model.OpCall{
+					BaseCall: model.BaseCall{
+						OpPath: "oppath2",
+					},
+					OpID: "secondopid",
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 1),
+	})
+	// first child -> first child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child1child1ID,
+				ParentID: &child1ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id1234567890",
+					Cmd:         []string{"./cmd", "arg1", "arg2", "arg3"},
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 2),
+	})
+	// first child -> second child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child1Child2Id",
+				ParentID: &child1ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 3),
+	})
+	// first child -> second child succeeds
+	objectUnderTest.HandleEvent(&model.Event{
+		CallEnded: &model.CallEnded{
+			Call: model.Call{
+				ID:       "child1Child2Id",
+				ParentID: &child1ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+			Outcome: model.OpOutcomeSucceeded,
+		},
+		Timestamp: timestamp.Add(time.Second * 4),
+	})
+	// second child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child2ID",
+				ParentID: &parentID,
+				If:       &child2If,
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 5),
+	})
+	// third child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child3ID",
+				ParentID: &parentID,
+				If:       &child3If,
+				Serial:   []*model.CallSpec{},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 6),
+	})
+	// first child -> third child
+	child1Child3ID := "child1Child3Id"
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child1Child3ID,
+				ParentID: &child1ID,
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 3),
+	})
+	// first child -> third child -> first child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child1Child3Child1Id",
+				ParentID: &child1Child3ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 3),
+	})
+	// first child -> third child failed
+	objectUnderTest.HandleEvent(&model.Event{
+		CallEnded: &model.CallEnded{
+			Call: model.Call{
+				ID:       "child1Child3Id",
+				ParentID: &child1ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+			Outcome: model.OpOutcomeFailed,
+		},
+		Timestamp: timestamp.Add(time.Second * 4),
+	})
+	// second child -> first child
+	containerName := "named-container"
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child2Child1Id",
+				ParentID: &child2ID,
+				Container: &model.ContainerCall{
+					Name:        &containerName,
+					ContainerID: "id0987654321",
+					Cmd:         []string{"./cmd"},
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 3),
+	})
+	// second child -> first child killed
+	objectUnderTest.HandleEvent(&model.Event{
+		CallEnded: &model.CallEnded{
+			Call: model.Call{
+				ID:       "child2Child1Id",
+				ParentID: &child2ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+			Outcome: model.OpOutcomeKilled,
+		},
+		Timestamp: timestamp.Add(time.Second * 4),
+	})
+	// third child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child3ID,
+				ParentID: &parentID,
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 1),
+	})
+	// third child -> first child
+	thirdChildName := "Third Child"
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				Name:     &thirdChildName,
+				ID:       "child3IDChild1ID",
+				ParentID: &child3ID,
+				Parallel: []*model.CallSpec{},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 1),
+	})
+	// third child succeeds, so its children should be collapsed
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child3ID,
+				ParentID: &parentID,
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 9),
+	})
+	// fourth child
+	child4ID := "child4ID"
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child4ID,
+				ParentID: &parentID,
+				Op: &model.OpCall{
+					BaseCall: model.BaseCall{
+						OpPath: "oppath2",
+					},
+					OpID: "secondopid",
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 1),
+	})
+	// fourth child -> first child
+	child4child1ID := "child4child1ID"
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       child4child1ID,
+				ParentID: &child4ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id1234567890",
+					Cmd:         []string{"./cmd", "arg1", "arg2", "arg3"},
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 2),
+	})
+	// fourth child -> second child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child4Child2Id",
+				ParentID: &child4ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 3),
+	})
+	// fourth child -> second child succeeds
+	objectUnderTest.HandleEvent(&model.Event{
+		CallEnded: &model.CallEnded{
+			Call: model.Call{
+				ID:       "child4Child2Id",
+				ParentID: &child4ID,
+				Container: &model.ContainerCall{
+					ContainerID: "id0987654321",
+					Image: &model.ContainerCallImage{
+						Ref: &containerRef,
+					},
+				},
+			},
+			Outcome: model.OpOutcomeSucceeded,
+		},
+		Timestamp: timestamp.Add(time.Second * 4),
+	})
+	// fourth child succeeds (should be collapsed)
+	objectUnderTest.HandleEvent(&model.Event{
+		CallEnded: &model.CallEnded{
+			Call: model.Call{
+				ID:       child4ID,
+				ParentID: &parentID,
+			},
+			Outcome: model.OpOutcomeSucceeded,
+		},
+		Timestamp: timestamp.Add(time.Second * 30),
+	})
+	// fifth child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:           "child5ID",
+				ParentID:     &parentID,
+				ParallelLoop: &model.ParallelLoopCall{},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 9),
+	})
+	// sixth child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:       "child6ID",
+				ParentID: &parentID,
+				Serial:   []*model.CallSpec{},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 9),
+	})
+	// seventh child
+	objectUnderTest.HandleEvent(&model.Event{
+		CallStarted: &model.CallStarted{
+			Call: model.Call{
+				ID:         "child7ID",
+				ParentID:   &parentID,
+				SerialLoop: &model.SerialLoopCall{},
+			},
+		},
+		Timestamp: timestamp.Add(time.Second * 9),
+	})
+
+	objectUnderTest.errors = append(objectUnderTest.errors, errors.New("this should show up as a warning"))
+
+	/* assert */
+	// the newline is here just for better test code readability
+	collapsedStr := "\n" + objectUnderTest.String(
+		StaticLoadingSpinner{},
+		timestamp.Add(time.Second*60),
+		true,
+	)
+	expectedCollapsedStr := `
+◎ oppath
+├─◎ oppath2
+│ ├─◉ ⋰ id123456 containerRef 58s ./cmd arg1 arg2 arg3
+│ ├─◉ ☑ id098765 containerRef 1s
+│ └─◎ ⚠ 1s
+│   └─◉ ⋰ id098765 containerRef 57s
+├─◎ if skipped
+│ └─◉️ ☒ id098765 named-container 1s
+├─◎ if
+│ │ serial
+│ └─◉ ⋰ Third Child parallel 59s
+├─◉ ⋰ 59s
+├─◉ ⋰ 51s
+├─◎ ☑ oppath2 29s (2 children)
+├─◉ ⋰ parallel loop 51s
+├─◉ ⋰ serial 51s
+└─◉ ⋰ serial loop 51s
+⚠️  this should show up as a warning`
+	g.Expect(collapsedStr).To(Equal(expectedCollapsedStr))
+
+	// the newline is here just for better test code readability
+	expandedStr := "\n" + objectUnderTest.String(
+		StaticLoadingSpinner{},
+		timestamp.Add(time.Second*60),
+		false,
+	)
+	expandedCollapsedStr := `
+◎ oppath
+├─◎ oppath2
+│ ├─◉ ⋰ id123456 containerRef 58s ./cmd arg1 arg2 arg3
+│ ├─◉ ☑ id098765 containerRef 1s
+│ └─◎ ⚠ 1s
+│   └─◉ ⋰ id098765 containerRef 57s
+├─◎ if skipped
+│ └─◉️ ☒ id098765 named-container 1s
+├─◎ if
+│ │ serial
+│ └─◉ ⋰ Third Child parallel 59s
+├─◉ ⋰ 59s
+├─◉ ⋰ 51s
+├─◎ ☑ oppath2 29s
+│ ├─◉ ⋰ id123456 containerRef 58s ./cmd arg1 arg2 arg3
+│ └─◉ ☑ id098765 containerRef 1s
+├─◉ ⋰ parallel loop 51s
+├─◉ ⋰ serial 51s
+└─◉ ⋰ serial loop 51s
+⚠️  this should show up as a warning`
+	g.Expect(expandedStr).To(Equal(expandedCollapsedStr))
+}

--- a/cli/internal/opgraph/formatting.go
+++ b/cli/internal/opgraph/formatting.go
@@ -1,0 +1,38 @@
+package opgraph
+
+import (
+	"regexp"
+	"unicode/utf8"
+
+	"github.com/fatih/color"
+)
+
+var muted = color.New(color.Faint)
+var highlighted = color.New(color.Bold)
+var success = color.New(color.FgGreen)
+var failed = color.New(color.FgRed)
+var warning = color.New(color.FgYellow)
+
+var ansiRegex = regexp.MustCompile("[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))")
+
+func stripAnsi(str string) string {
+	return ansiRegex.ReplaceAllString(str, "")
+}
+
+func stripAnsiToLength(str string, length int) string {
+	for countChars(stripAnsi(str)) > length {
+		_, size := utf8.DecodeLastRuneInString(str)
+		str = str[:len(str)-size]
+	}
+	return str
+}
+
+func countChars(str string) int {
+	count := 0
+	for len(str) > 0 {
+		_, size := utf8.DecodeLastRuneInString(str)
+		count++
+		str = str[:len(str)-size]
+	}
+	return count
+}

--- a/cli/internal/opgraph/formatting_test.go
+++ b/cli/internal/opgraph/formatting_test.go
@@ -1,0 +1,57 @@
+package opgraph
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStripAnsi(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	str := "test"
+	ansiStr := "\033[1Atest"
+	withoutAnsi := stripAnsi(ansiStr)
+
+	g.Expect(withoutAnsi).To(Equal(str), "stripped string is not equal to original")
+}
+
+func TestStripAnsi_noAnsi(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	str := "◉ ⠴ ./test"
+	ansiStr := "◉ ⠴ [1m./test[0m"
+	withoutAnsi := stripAnsi(ansiStr)
+
+	g.Expect(withoutAnsi).To(Equal(str), "stripped string is not equal to original")
+}
+
+func TestStripAnsiToLength(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ansiStr := "\033[1Atesting a string"
+	stripped := stripAnsiToLength(ansiStr, 9)
+	expected := "\033[1Atesting a"
+
+	g.Expect(stripped).To(Equal(expected))
+}
+
+func TestStripAnsiToLength_escapeCodeInMid(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ansiStr := "\033[1Atesting\033[0m a\033[1A string"
+	stripped := stripAnsiToLength(ansiStr, 9)
+	expected := "\033[1Atesting\033[0m a\033[1A"
+
+	g.Expect(stripped).To(Equal(expected))
+}
+
+func TestStripAnsiToLength_noAnsi(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	ansiStr := "testing a string"
+	stripped := stripAnsiToLength(ansiStr, 9)
+	expected := "testing a"
+
+	g.Expect(stripped).To(Equal(expected))
+}

--- a/cli/internal/opgraph/loading.go
+++ b/cli/internal/opgraph/loading.go
@@ -1,0 +1,30 @@
+package opgraph
+
+import "time"
+
+// LoadingSpinner has a string representation that indicates something's loading
+type LoadingSpinner interface {
+	String() string
+}
+
+// DotLoadingSpinner is a LoadingSpinner that uses brail dots that rotate
+type DotLoadingSpinner struct {
+	state       int
+	lastChanged time.Time
+}
+
+var loadingRunes = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+func (l DotLoadingSpinner) String() string {
+	now := time.Now()
+	ms := now.UnixNano() / int64(time.Millisecond)
+	r := loadingRunes[(ms/int64(100))%int64(len(loadingRunes))]
+	return string(r)
+}
+
+// StaticLoadingSpinner is a LoadingSpinner that doesn't spin
+type StaticLoadingSpinner struct{}
+
+func (StaticLoadingSpinner) String() string {
+	return "⋰"
+}

--- a/cli/internal/opgraph/loading_test.go
+++ b/cli/internal/opgraph/loading_test.go
@@ -1,0 +1,23 @@
+package opgraph
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestDotLoadingSpinner(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// arrange
+	var objectUnderTest DotLoadingSpinner
+
+	// act
+	l := objectUnderTest.String()
+
+	// assert
+	_, size := utf8.DecodeRuneInString(l)
+	g.Expect(size).To(Equal(3))
+	g.Expect(len(l)).To(Equal(size))
+}

--- a/cli/internal/opgraph/outputmanager.go
+++ b/cli/internal/opgraph/outputmanager.go
@@ -1,0 +1,86 @@
+package opgraph
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// OutputManager allows printing a "resettable" thing at the bottom of a stream
+// of terminal output, when a tty is used
+type OutputManager struct {
+	out        io.Writer
+	getWidth   func() (int, error)
+	lastHeight int
+}
+
+// NewOutputManager returns a new OutputManager
+func NewOutputManager() OutputManager {
+	return OutputManager{
+		getWidth: func() (int, error) {
+			w, _, err := term.GetSize(int(os.Stdout.Fd()))
+			return w, err
+		},
+		out: os.Stdout,
+	}
+}
+
+// Clear clears the last thing printed by this object
+func (o *OutputManager) Clear() error {
+	w, err := o.getWidth()
+	if err != nil {
+		return err
+	}
+	// cursor to start of line (real big number) + clear line
+	io.WriteString(o.out, fmt.Sprintf("\033[%dD\033[K", w))
+	for i := 1; i < o.lastHeight; i++ {
+		// move up one line + clear line
+		io.WriteString(o.out, "\033[1A\033[K")
+	}
+	return nil
+}
+
+// Print prints the given string, with a preceding separator and width limited
+// to the size of the terminal
+func (o *OutputManager) Print(str string) error {
+	w, err := o.getWidth()
+	if err != nil {
+		return err
+	}
+	lines := strings.Split(str, "\n")
+
+	ruleWidth := 0
+	for _, line := range lines {
+		visualLen := countChars(stripAnsi(line))
+		if visualLen > ruleWidth {
+			ruleWidth = visualLen
+		}
+	}
+	if ruleWidth > w {
+		ruleWidth = w
+	}
+
+	io.WriteString(o.out, fmt.Sprintln(strings.Repeat("┄", ruleWidth)))
+
+	for i, line := range lines {
+		withoutAnsi := stripAnsi(line)
+		if countChars(withoutAnsi) > w {
+			// - append an ellipsis to make it more obvious the line's being truncated
+			// - remove _two_ chars, not just one for the ellipsis, because the cursor
+			//   will take up an additional space and cause output issues
+			// - append a "reset" code to prevent color wrapping to next line
+			io.WriteString(o.out, stripAnsiToLength(line, w-2)+"…\033[0m")
+		} else {
+			io.WriteString(o.out, line)
+		}
+		if i < len(lines)-1 {
+			io.WriteString(o.out, "\n")
+		}
+	}
+
+	o.lastHeight = len(lines) + 1
+	return nil
+}

--- a/cli/internal/opgraph/outputmanager_test.go
+++ b/cli/internal/opgraph/outputmanager_test.go
@@ -1,0 +1,101 @@
+package opgraph
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestNewOutputManager(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	objectUnderTest := NewOutputManager()
+
+	g.Expect(objectUnderTest).NotTo(BeNil())
+	_, err := objectUnderTest.getWidth()
+	g.Expect(err).NotTo(BeNil(), "in tests, terminal width isn't available")
+
+	g.Expect(objectUnderTest.Print("")).NotTo(BeNil())
+	objectUnderTest.Clear()
+}
+
+func TestOutputManagerShortLines(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// arrange
+	var buff bytes.Buffer
+	objectUnderTest := OutputManager{
+		getWidth: func() (int, error) { return 80, nil },
+		out:      &buff,
+	}
+
+	// act
+	err := objectUnderTest.Print(`testing
+the drinks should just be like a glass of water
+inspired by space jam and who knows`)
+
+	// assert
+	g.Expect(err).To(BeNil())
+	expected := `┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+testing
+the drinks should just be like a glass of water
+inspired by space jam and who knows`
+	g.Expect(buff.String()).To(Equal(expected))
+	g.Expect(objectUnderTest.lastHeight).To(Equal(4))
+}
+
+func TestOutputManagerLongLines(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// arrange
+	var buff bytes.Buffer
+	objectUnderTest := OutputManager{
+		getWidth: func() (int, error) { return 80, nil },
+		out:      &buff,
+	}
+	longLine := strings.Repeat("-", 80)
+	longerLine := strings.Repeat("-", 81)
+
+	// act
+	err := objectUnderTest.Print(fmt.Sprintf(`testing
+%s
+%s
+testing3`, longLine, longerLine))
+
+	// assert
+	g.Expect(err).To(BeNil())
+	expected := fmt.Sprintf(`┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄
+testing
+--------------------------------------------------------------------------------
+------------------------------------------------------------------------------…%s
+testing3`, "\033[0m")
+	g.Expect(buff.String()).To(Equal(expected))
+	g.Expect(objectUnderTest.lastHeight).To(Equal(5))
+}
+
+func TestOutputManagerClearing(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// arrange
+	var buff bytes.Buffer
+	objectUnderTest := OutputManager{
+		getWidth: func() (int, error) { return 80, nil },
+		out:      &buff,
+	}
+
+	// act
+	objectUnderTest.Print(`testing
+the drinks should just be like a glass of water
+inspired by space jam and who knows`)
+	ioutil.ReadAll(&buff)
+	objectUnderTest.Clear()
+
+	// assert
+	expected := "\x1b[80D\x1b[K\x1b[1A\x1b[K\x1b[1A\x1b[K\x1b[1A\x1b[K"
+	g.Expect(buff.String()).To(Equal(expected))
+	g.Expect(objectUnderTest.lastHeight).To(Equal(4))
+}

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.19.1
 	k8s.io/apimachinery v0.19.1


### PR DESCRIPTION
When running an op via opctl run:
  - display progress via a live call graph
  - prefix log lines emitted by workloads with their op id & ref; closes #664

Note: this is basically a minimal port of the above features from @apexskier 's [branch](https://github.com/opctl/opctl/tree/mini-opctl). 

Just want to say a huge round of applause and thanks to @apexskier . This is some super cool & useful functionality. 