### PR TITLE
Fix github actions install link

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,15 +28,7 @@ jobs:
       id: branch_name_pr
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
 
-    - name: Download opctl
-      uses: dsaltares/fetch-gh-release-asset@0.0.5
-      with:
-        repo: opctl/opctl
-        version: tags/0.1.46
-        file: opctl0.1.46.linux.tgz
-        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install Opctl
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
 
-    - name: Extract opctl
-      run: tar -xvzf opctl0.1.46.linux.tgz
-
-    - run: ./opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} build
+    - run: opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} build

--- a/website/docs/setup/azure-pipelines.md
+++ b/website/docs/setup/azure-pipelines.md
@@ -19,7 +19,7 @@ Type: "Inline"
 
 Script:
 ```bash
-curl -L https://github.com/opctl/opctl/releases/download/latest/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
 
 # manually create an opctl node.
 # custom node data dir required because VSTS only makes build dir available to docker daemon

--- a/website/docs/setup/github.md
+++ b/website/docs/setup/github.md
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/download/latest/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     
     - name: Build
       run: opctl run build

--- a/website/docs/setup/travis.md
+++ b/website/docs/setup/travis.md
@@ -19,7 +19,7 @@ a matter of defining your `travis.yml` as follows:
 language: generic
 sudo: required
 before_script:
-- curl -L https://github.com/opctl/opctl/releases/download/latest/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+- curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
 services:
 - docker
 script:


### PR DESCRIPTION
This also switches the main repo to use the documented github actions setup, which ensures it's using the most recent version of opctl and is less verbose.