### PR TITLE
Stop Docker containers gracefully before removing them

### DIFF
--- a/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
+++ b/sdks/go/node/core/containerruntime/docker/deleteContainerIfExists_test.go
@@ -33,6 +33,10 @@ var _ = Context("DeleteContainerIfExists", func() {
 		)
 
 		/* assert */
+		actualCtx, actualContainerName, _ := fakeDockerClient.ContainerStopArgsForCall(0)
+		Expect(actualCtx).To(Equal(providedCtx))
+		Expect(actualContainerName).To(Equal(expectedContainerName))
+
 		actualCtx,
 			actualContainerName,
 			actualContainerRemoveOptions := fakeDockerClient.ContainerRemoveArgsForCall(0)

--- a/sdks/go/node/core/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer.go
@@ -84,6 +84,7 @@ func (cr _runContainer) RunContainer(
 	containerName := getContainerName(req.ContainerID)
 	defer func() {
 		// ensure container always cleaned up: gracefully stop then delete it
+		// @TODO: consolidate logic with DeleteContainerIfExists
 		newCtx := context.Background() // always use a fresh context, to clean up after cancellation
 		stopTimeout := 3 * time.Second
 		cr.dockerClient.ContainerStop(

--- a/sdks/go/node/core/containerruntime/docker/runContainer_test.go
+++ b/sdks/go/node/core/containerruntime/docker/runContainer_test.go
@@ -56,6 +56,9 @@ var _ = Context("RunContainer", func() {
 		)
 
 		/* assert */
+		_, actualContainerName, _ := fakeDockerClient.ContainerStopArgsForCall(0)
+		Expect(actualContainerName).To(Equal(fmt.Sprintf("opctl_%s", providedReq.ContainerID)))
+
 		_, actualContainerName, actualContainerRemoveOptions := fakeDockerClient.ContainerRemoveArgsForCall(0)
 		Expect(actualContainerName).To(Equal(fmt.Sprintf("opctl_%s", providedReq.ContainerID)))
 		Expect(actualContainerRemoveOptions).To(Equal(expectedContainerRemoveOptions))


### PR DESCRIPTION
This notifies containers with a SIGTERM signal, giving them a chance to gracefully shut down within a 3s timeout window. Containers that fail to stop within that window will be forced to terminate with a SIGKILL.

Note that the k8s runtime's pod deletion defaults to a graceful termination, so this change also brings the Docker runtime into alignment.