### PR TITLE
Update CLI reference sidebar labels for CLI nested commands

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -13,7 +13,7 @@ Ops are defined in a language called opspec (portmanteau of operation specificat
 - Portable ML (machine learning) pipelines.
 
 ## CLI
-The opctl CLI allows managing ops, nodes, events (logs), and opctl updates. See [reference docs](reference/cli) for full details.
+The opctl CLI allows managing ops, nodes, events (logs), and opctl updates. See [reference docs](reference/cli/global-options.md) for full details.
 
 ![opctl CLI](/img/opctl-cli.png)
 

--- a/website/docs/reference/cli/auth/index.md
+++ b/website/docs/reference/cli/auth/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Overview
+sidebar_label: auth
 title: opctl auth
 ---
 Manage auth for OCI image registries.

--- a/website/docs/reference/cli/node/index.md
+++ b/website/docs/reference/cli/node/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Overview
+sidebar_label: node
 title: opctl node
 ---
 Manage nodes

--- a/website/docs/reference/cli/op/index.md
+++ b/website/docs/reference/cli/op/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Overview
+sidebar_label: op
 title: opctl op
 ---
 Manage ops

--- a/website/docs/training/containers/how-do-i-communicate-with-an-opctl-container.md
+++ b/website/docs/training/containers/how-do-i-communicate-with-an-opctl-container.md
@@ -3,7 +3,7 @@ title: How do I communicate with an opctl container?
 ---
 
 ## TLDR;
-Adding a [ports](../../reference/opspec/op-directory/op/call/container/index#ports) attribute to a container binds container ports to the opctl host.
+Adding a [ports](../../reference/opspec/op-directory/op/call/container/index.md#ports) attribute to a container binds container ports to the opctl host.
 
 ## Example
 1. Start this op: 

--- a/website/docs/training/containers/how-do-i-get-opctl-containers-to-communicate.md
+++ b/website/docs/training/containers/how-do-i-get-opctl-containers-to-communicate.md
@@ -5,11 +5,11 @@ title: How do I get opctl containers to communicate?
 ## TLDR;
 Opctl attaches all containers to a virtual overlay network.  
 
-Adding a [name](../../reference/opspec/op-directory/op/call/container/index#name) attribute to container(s) adds a corresponding network wide DNS A record which resolves to the assigned ip(s) of the container(s).
+Adding a [name](../../reference/opspec/op-directory/op/call/container/index.md#name) attribute to container(s) adds a corresponding network wide DNS A record which resolves to the assigned ip(s) of the container(s).
 
 Whether containers are defined in the same op or not makes no difference, they can still reach each other.
 
-If multiple containers have the same [name](../../reference/opspec/op-directory/op/call/container/index#name) requests will be load balanced across them.
+If multiple containers have the same [name](../../reference/opspec/op-directory/op/call/container/index.md#name) requests will be load balanced across them.
 
 ## Example
 1. Run this op:

--- a/website/docs/training/containers/how-do-i-run-a-container.md
+++ b/website/docs/training/containers/how-do-i-run-a-container.md
@@ -3,7 +3,7 @@ title: How do I run a container?
 ---
 
 ## TLDR;
-Opctl supports running an [OCI](https://opencontainers.org/) image based container by defining a [container call](../../reference/opspec/op-directory/op/call/container/index).
+Opctl supports running an [OCI](https://opencontainers.org/) image based container by defining a [container call](../../reference/opspec/op-directory/op/call/container/index.md).
 
 > Note: a common place to obtain [OCI](https://opencontainers.org/) images is [Docker Hub](https://hub.docker.com/).
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,6 +6,7 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'opctl', // Usually your GitHub org/user name.
   projectName: 'opctl', // Usually your repo name.
+  trailingSlash: false,
   themeConfig: {
     algolia: {
       appId: 'E19H3NL09D',


### PR DESCRIPTION
This PR changes the sidebar labels on the website CLI reference docs for nested CLI commands. Previously they were called "Overview" but this does not work as intended with latest version of Docusaurus which supports the concept of an index page; we therefore don't need an Overview page. 