### PR TITLE
Fixes CLI no longer logs errors occurring in parallel calls; closes #1032

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ accordance with
 ### Fixed
 
 - [Node locking mechanism doesn't ensure process is opctl](https://github.com/opctl/opctl/issues/913)
+- [CLI no longer logs errors occurring in parallel calls](https://github.com/opctl/opctl/issues/1032)
 
 ## 0.1.48 - 2021-08-13
 

--- a/cli/internal/clioutput/cliOutput.go
+++ b/cli/internal/clioutput/cliOutput.go
@@ -130,6 +130,9 @@ func (clio _cliOutput) containerExited(event *model.Event) {
 		message += "unknown container " + message
 	}
 	message = color(message)
+	if event.CallEnded.Error != nil {
+		message += color(":") + " " + event.CallEnded.Error.Message
+	}
 
 	io.WriteString(
 		writer,


### PR DESCRIPTION
This PR updates the CLI event logging logic to include container errors, which should resolve #1032 