### PR TITLE
Update K8s container runtime to explicitly delete terminated pods

### DIFF
--- a/.opspec/release/op.yml
+++ b/.opspec/release/op.yml
@@ -31,6 +31,9 @@ inputs:
             type: string
         required: [accessToken, username]
       description: configuration required to interact w/ github
+  HOME:
+    dir:
+      description: Home directory of caller; used to access go modules
   version:
     string:
       constraints: { format: semver }
@@ -42,6 +45,7 @@ run:
         inputs:
           dockerSocket:
           gitBranch:
+          HOME:
           version:
     - parallel:
         - op:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,18 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
-## [Unreleased]
+## 0.1.49 - 2022-09-21
 
 ### Added
 
 - opspec now supports gt, gte, lt, lte predicates
-- `opctl node kill` will now stop and remove any opctl managed containers (note: qemu & docker container runtimes only)
+- `opctl node kill` will now stop and remove any opctl managed containers
 - introduced `opctl node delete` command which "Deletes a node. This is destructive! all node data including auth, caches, and operation state will be permanently removed."
 
 ### Changed
 
 - upgrading to this version from prior versions is destructive! all node data including auth, caches, and operation state will be permanently removed.
+- K8s container runtime now explicitly deletes terminated pods
 
 ### Fixed
 


### PR DESCRIPTION
This PR updates the k8s container runtime to explicitly delete terminated pods in order to avoid leaking terminated pods. Technically k8s does this automatically per [terminated-pod-gc-threshold](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-garbage-collection) but managed k8s such as EKS and GKE might not allow configuring this and the default is reported to be so high it could effect performance. 