### PR TITLE
Fix crash on bad slice input parameter

### DIFF
--- a/cli/internal/cliparamsatisfier/inputsrc/slice/slice.go
+++ b/cli/internal/cliparamsatisfier/inputsrc/slice/slice.go
@@ -14,6 +14,9 @@ func New(
 		// get parts
 		parts := strings.SplitN(arg, sep, 2)
 		inputName := parts[0]
+		if len(parts) < 2 {
+			continue
+		}
 		inputValue := parts[1]
 
 		argMap[inputName] = inputValue

--- a/cli/internal/cliparamsatisfier/inputsrc/slice/slice.go
+++ b/cli/internal/cliparamsatisfier/inputsrc/slice/slice.go
@@ -13,10 +13,10 @@ func New(
 	for _, arg := range args {
 		// get parts
 		parts := strings.SplitN(arg, sep, 2)
-		inputName := parts[0]
 		if len(parts) < 2 {
 			continue
 		}
+		inputName := parts[0]
 		inputValue := parts[1]
 
 		argMap[inputName] = inputValue


### PR DESCRIPTION
There's a crash that can be triggered when using an array input and forgetting to use the `name=` syntax on the CLI.

Before:

<img width="669" alt="auth-testing — -bash — bash - Terminal - 2022-10-06 at 12 24 15@2x" src="https://user-images.githubusercontent.com/329222/194390131-4688ada4-d1d8-4e46-989c-a76ba055801a.png">

After:

<img width="462" alt="auth-testing — -bash — bash - Terminal - 2022-10-06 at 12 24 20@2x" src="https://user-images.githubusercontent.com/329222/194390185-69f7b3f5-4c63-47ee-a8b5-3f59c6be241c.png">
