### PR TITLE
Support variable references in call names

### DIFF
--- a/sdks/go/opspec/interpreter/call/interpret.go
+++ b/sdks/go/opspec/interpreter/call/interpret.go
@@ -3,13 +3,14 @@ package call
 import (
 	"context"
 	"fmt"
-
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/container"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/op"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/parallelloop"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/predicates"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/serialloop"
+	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
+	"github.com/pkg/errors"
 )
 
 // Interpret a spec into a call
@@ -23,9 +24,20 @@ func Interpret(
 	rootCallID string,
 	dataDirPath string,
 ) (*model.Call, error) {
+	var name *string
+	if callSpec.Name != nil {
+		value, err := str.Interpret(scope, *callSpec.Name)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to interpret call name")
+		}
+		if value.String == nil {
+			return nil, errors.New("call name not interpretable to string")
+		}
+		name = value.String
+	}
 	call := &model.Call{
 		ID:       id,
-		Name:     callSpec.Name,
+		Name:     name,
 		Needs:    callSpec.Needs,
 		ParentID: parentID,
 		RootID:   rootCallID,

--- a/sdks/go/opspec/interpreter/call/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/interpret_test.go
@@ -250,4 +250,68 @@ var _ = Context("Interpret", func() {
 
 		})
 	})
+	Context("callSpec.Name not nil", func() {
+		It("should return expected result", func() {
+			/* arrange */
+			providedName := "test-$(value)"
+			stringValue := "hello-world"
+			providedScope := map[string]*model.Value{
+				"value": {String: &stringValue},
+			}
+			providedID := "providedID"
+			providedOpPath := "providedOpPath"
+			providedParentIDValue := "providedParentID"
+			providedParentID := &providedParentIDValue
+			providedRootCallID := "providedRootCallID"
+			providedDataDirPath, err := os.MkdirTemp("", "")
+			if err != nil {
+				panic(err)
+			}
+
+			containerSpec := model.ContainerCallSpec{
+				Image: &model.ContainerCallImageSpec{
+					Ref: "ref",
+				},
+			}
+
+			expectedContainer, err := container.Interpret(
+				providedScope,
+				&containerSpec,
+				providedID,
+				providedOpPath,
+				providedDataDirPath,
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			expectedName := "test-hello-world"
+			expectedCall := &model.Call{
+				Name:      &expectedName,
+				Container: expectedContainer,
+				ID:        providedID,
+				ParentID:  providedParentID,
+				RootID:    providedRootCallID,
+			}
+
+			/* act */
+			actualCall, actualError := Interpret(
+				context.Background(),
+				providedScope,
+				&model.CallSpec{
+					Container: &containerSpec,
+					Name:      &providedName,
+				},
+				providedID,
+				providedOpPath,
+				providedParentID,
+				providedRootCallID,
+				providedDataDirPath,
+			)
+
+			/* assert */
+			Expect(actualError).To(BeNil())
+			Expect(actualCall).To(Equal(expectedCall))
+		})
+	})
 })


### PR DESCRIPTION
Right now, it's often hard to distinguish between runs of a `parallelLoop`. You can add a name, but since there's a single `run` call it's the same name for each run. This makes a call's name interpreted as a string, which allows using variables (such as a variable for the parallel loop) as the name. (This also applies to `serialLoop`)

For this minimal example op the final graph is a lot more usable (I can tell what failed easier):
```yml
name: testloop
description: ""
inputs:
  list:
    array:
      description: ""
run:
  parallelLoop:
    range: $(list)
    vars:
      value: $(value)
    run:
      name: validate-$(value)
      container:
        image: { ref: "apexskier/toolbox" }
        envVars:
          value:
        cmd:
          - bash
          - -ce
          - |
            echo "$value" | grep a
```

Called with
```bash
opctl run -a list=["cat","dog","rabbit"] testloop
```

Output before:

```
◎ ⚠ ./testloop 2.709231s
├─◉ ⚠ parallel loop 2.706381s
├─◉ ☑ validate-$(value) b0198e6e docker.io/apexskier/toolbox 2.642053s bash -ce echo "$value" | grep a\n
├─◉ ⚠ validate-$(value) cfd2dd75 docker.io/apexskier/toolbox 2.666758s bash -ce echo "$value" | grep a\n
└─◉️ ☒ validate-$(value) 57b8614e docker.io/apexskier/toolbox 2.706056s bash -ce echo "$value" | grep a\n
```

Output after:

```
◎ ⚠ ./testloop 2.49059s
├─◉ ⚠ parallel loop 2.48903s
├─◉ ☑ validate-rabbit bf22fd9e docker.io/apexskier/toolbox 2.282984s bash -ce echo "$value" | grep a\n
├─◉️ ☒ validate-cat 7b090cf5 docker.io/apexskier/toolbox 2.48872s bash -ce echo "$value" | grep a\n
└─◉ ⚠ validate-dog 80d04ac0 docker.io/apexskier/toolbox 2.32806s bash -ce echo "$value" | grep a\n
```