### PR TITLE
Update release ops to publish arm64 arch images

### DIFF
--- a/.opspec/release/to-docker/dind.Dockerfile
+++ b/.opspec/release/to-docker/dind.Dockerfile
@@ -1,6 +1,6 @@
-FROM docker:20.10.17-dind
-
-COPY opctl /usr/local/bin/
+FROM --platform=$TARGETPLATFORM docker:20.10.17-dind
+ARG TARGETOS TARGETARCH
+COPY opctl-$TARGETOS-$TARGETARCH /usr/local/bin/opctl
 COPY entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["entrypoint.sh"]

--- a/.opspec/release/to-docker/dood.Dockerfile
+++ b/.opspec/release/to-docker/dood.Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:3.11.3
-
-COPY opctl /usr/local/bin/
+FROM --platform=$TARGETPLATFORM alpine:3.11.3
+ARG TARGETOS TARGETARCH
+COPY opctl-$TARGETOS-$TARGETARCH /usr/local/bin/opctl
 EXPOSE 42224/tcp
 CMD [ "opctl", "node", "create" ]

--- a/.opspec/release/to-docker/op.yml
+++ b/.opspec/release/to-docker/op.yml
@@ -15,33 +15,47 @@ inputs:
       constraints: { format: semver }
       description: version of opctl being released
 run:
-  parallelLoop:
-    range:
-      - dind
-      - dood
-    vars:
-      value: $(imageRefVariant)
-    run:
-      serial:
-        - op:
-            ref: github.com/opspec-pkgs/docker.image.build#2.1.0
-            inputs:
-              imageName: opctl/opctl:$(version)-$(imageRefVariant)
-              dockerfile: $(./$(imageRefVariant).Dockerfile)
-              context:
-                /opctl:
-                  data: $(../../../cli/opctl-linux-amd64)
-                /entrypoint.sh: 
-                  data: $(./entrypoint.sh)
-              username: $(dockerUsername)
-              password: $(dockerPassword)
-              registry: https://docker.io
-            outputs:
-              imageTar:
-        - op:
-            ref: github.com/opspec-pkgs/docker.image.push#2.1.0
-            inputs:
-              imageTar:
-              imageName: opctl/opctl:$(version)-$(imageRefVariant)
-              username: $(dockerUsername)
-              password: $(dockerPassword)
+  serial:
+    - op:
+        ref: github.com/opspec-pkgs/base64.encode#1.1.0
+        inputs:
+          rawValue: $(dockerUsername):$(dockerPassword)
+        outputs:
+          encodedValue: $(b64DockerAuth)
+    - parallelLoop:
+        range:
+          - dind
+          - dood
+        vars:
+          value: $(imageVariant)
+        run:
+          serial:
+            - container:
+                image: 
+                  ref: moby/buildkit:latest
+                cmd:
+                  - sh
+                  - -ce
+                  - >
+                    buildctl-daemonless.sh
+                    build
+                    --frontend dockerfile.v0
+                    --local context=/buildCtx
+                    --local dockerfile=/
+                    --progress plain
+                    --opt platform=linux/amd64,linux/arm64
+                    --output type=image,name=docker.io/opctl/opctl:$(version)-$(imageVariant),push=true
+                dirs:
+                  /buildCtx:
+                    /entrypoint.sh:
+                      data: $(./entrypoint.sh)
+                    /opctl-linux-amd64: 
+                      data: $(../../../cli/opctl-linux-amd64)
+                    /opctl-linux-arm64: 
+                      data: $(../../../cli/opctl-linux-arm64)
+                files:
+                  /Dockerfile: $(./$(imageVariant).Dockerfile)
+                  /root/.docker/config.json:
+                    auths:
+                      https://index.docker.io/v1/:
+                        auth: $(b64DockerAuth)

--- a/cli/.opspec/compile/op.yml
+++ b/cli/.opspec/compile/op.yml
@@ -12,12 +12,14 @@ inputs:
 run:
   parallelLoop:
     range:
-      - os: darwin
-        arch: amd64
-      - os: darwin
-        arch: arm64
-      - os: linux
-        arch: amd64
+      - arch: amd64
+        os: darwin
+      - arch: arm64
+        os: darwin
+      - arch: amd64
+        os: linux
+      - arch: arm64
+        os: linux
     vars:
       value: $(target)
     run:


### PR DESCRIPTION
This PR updates the release ops to publish the opctl/opctl docker hub images in both arm64 and amd64 architectures.