### PR TITLE
Properly handle variable op references in op visualization UI

### DIFF
--- a/sdks/go/node/containerruntime/docker/isGpuSupported.go
+++ b/sdks/go/node/containerruntime/docker/isGpuSupported.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"runtime"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -24,6 +25,11 @@ func isGpuSupported(
 	dockerClient client.CommonAPIClient,
 	imagePullCreds *model.Creds,
 ) (bool, error) {
+	if runtime.GOOS != "linux" {
+		// GPU passthrough only available when host is linux
+		return false, nil
+	}
+
 	containerName := getContainerName(fmt.Sprintf("gpu-check-%s", uuid.NewV4().String()))
 
 	defer dockerClient.ContainerRemove(

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "ace-builds": "^1.4.12",
+    "buffer": "^6.0.3",
     "js-yaml": "^3.14.1",
     "path-browserify": "^1.0.1",
     "react": "^17.0.1",

--- a/webapp/src/components/CallHasOp/index.tsx
+++ b/webapp/src/components/CallHasOp/index.tsx
@@ -19,9 +19,15 @@ export default function CallHasOp(
     parentOpRef
   }: Props
 ) {
-  const opRef = opCall.ref.startsWith('.') && parentOpRef
-    ? path.join(parentOpRef, opCall.ref)
-    : opCall.ref
+  let opRef: string
+  if (opCall.ref.startsWith('$(') && parentOpRef) {
+    // interpolate by trimming "$(" prefix and ")"" suffix
+    opRef = path.join(parentOpRef, opCall.ref.slice(2, -1))
+  } else if (opCall.ref.startsWith('.') && parentOpRef) {
+    opRef = path.join(parentOpRef, opCall.ref)
+  } else {
+    opRef = opCall.ref
+  }
 
   const [op, setOp] = useState(null as any)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3199,6 +3199,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -3351,6 +3356,14 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 builtin-modules@^3.1.0:
   version "3.3.0"
@@ -5794,6 +5807,11 @@ identity-obj-proxy@3.0.0, identity-obj-proxy@^3.0.0:
   integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
   dependencies:
     harmony-reflect "^1.4.6"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.0:
   version "5.2.4"


### PR DESCRIPTION
This PR is a small fix for the op visualization UI to properly handle variable op references. 

unrelated) it also fixes a warning from webpack in webapp about buffer dependency missing and optimizes the gpu support check on non-linux platforms.

### before
<img width="1792" alt="before" src="https://user-images.githubusercontent.com/2335774/235553403-13267666-2d00-4394-a6ab-59a903d33b7f.png">

### after
<img width="1786" alt="after" src="https://user-images.githubusercontent.com/2335774/235553407-2b3f2bcd-76cf-48dd-b037-8247c55b2b57.png">
