### PR TITLE
Support variable reference as container.cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## 0.1.51 - 2023-06-01
+
+### Added
+
+- [Variable reference as `container.cmd`](https://github.com/opctl/opctl/issues/1064)
+
+### Fixed
+
+- Simultaneously defining a default plus constraints on an object or array input results in a validation error
+
 ## 0.1.50 - 2023-05-01
 
 ### Added

--- a/opspec/opfile/jsonschema.json
+++ b/opspec/opfile/jsonschema.json
@@ -852,12 +852,8 @@
           "type": "object",
           "properties": {
             "cmd": {
-              "description": "Command run by a container; overrides any set at the image level",
-              "type": "array",
-              "items": {
-                "description": "Expression coercible to string value",
-                "$ref": "#/definitions/expression"
-              }
+              "description": "Expression coercible to array of strings used as the command run by a container; overrides any set at the image level",
+              "$ref": "#/definitions/arrayExpression"
             },
             "dirs": {
               "type": "object",

--- a/sdks/go/model/opSpec.go
+++ b/sdks/go/model/opSpec.go
@@ -27,7 +27,7 @@ type CallSpec struct {
 // ContainerCallSpec is a spec for calling a container
 type ContainerCallSpec struct {
 	// Cmd entries will be interpreted to strings
-	Cmd []interface{} `json:"cmd,omitempty"`
+	Cmd interface{} `json:"cmd,omitempty"`
 	// Dirs entries will be interpreted to dirs
 	Dirs map[string]interface{} `json:"dirs,omitempty"`
 

--- a/sdks/go/opspec/interpreter/call/container/cmd/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/cmd/interpret.go
@@ -2,17 +2,30 @@ package cmd
 
 import (
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec/interpreter/array"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
 )
 
 // Interpret a container cmd
 func Interpret(
 	scope map[string]*model.Value,
-	containerCallSpecCmd []interface{},
+	containerCallSpecCmd interface{},
 ) ([]string, error) {
+	if containerCallSpecCmd == nil {
+		return []string{}, nil
+	}
+
+	containerCallCmdArray, err := array.Interpret(
+		scope,
+		containerCallSpecCmd,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	containerCallCmd := []string{}
 
-	for _, cmdEntryExpression := range containerCallSpecCmd {
+	for _, cmdEntryExpression := range *containerCallCmdArray.Array {
 		// interpret each entry as string
 		cmdEntry, err := str.Interpret(scope, cmdEntryExpression)
 		if err != nil {

--- a/sdks/go/opspec/interpreter/call/container/cmd/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/cmd/interpret_test.go
@@ -15,7 +15,7 @@ var _ = Context("Interpret", func() {
 				/* arrange */
 				identifier := "identifier"
 				providedScope := map[string]*model.Value{
-					identifier: &model.Value{String: new(string)},
+					identifier: {String: new(string)},
 				}
 
 				cmd2 := "cmd2"

--- a/sdks/go/opspec/interpreter/call/container/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret_test.go
@@ -35,7 +35,7 @@ var _ = Context("Interpret", func() {
 			)
 
 			/* assert */
-			Expect(actualErr).To(MatchError("unable to interpret $() to string: unable to interpret '' as reference: '' not in scope"))
+			Expect(actualErr).To(MatchError("unable to interpret [$()] to array: unable to interpret '$()' as array initializer item: unable to interpret '' as reference: '' not in scope"))
 		})
 	})
 

--- a/sdks/go/opspec/interpreter/call/op/inputs/interpret.go
+++ b/sdks/go/opspec/interpreter/call/op/inputs/interpret.go
@@ -32,6 +32,7 @@ func Interpret(
 			opScratchDir,
 		)
 		if err != nil {
+			fmt.Println(argName, err.Error())
 			paramErrMap[argName] = err
 		}
 	}

--- a/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/array/validate.go
@@ -27,11 +27,18 @@ func Validate(
 		return []error{err}
 	}
 
+	unboxedValueAsArray, err := valueAsArray.Unbox()
+	if err != nil {
+		return []error{
+			err,
+		}
+	}
+
 	// guard no constraints
 	if constraints != nil {
 		errs := []error{}
 
-		valueJSONBytes, err := json.Marshal(valueAsArray.Array)
+		valueJSONBytes, err := json.Marshal(unboxedValueAsArray)
 		if err != nil {
 			// handle syntax errors specially
 			return append(

--- a/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
+++ b/sdks/go/opspec/interpreter/call/op/params/param/object/validate.go
@@ -28,11 +28,18 @@ func Validate(
 		return []error{err}
 	}
 
+	unboxedValueAsObject, err := valueAsObject.Unbox()
+	if err != nil {
+		return []error{
+			err,
+		}
+	}
+
 	// guard no constraints
 	if constraints != nil {
 		errs := []error{}
 
-		valueJSONBytes, err := json.Marshal(valueAsObject.Object)
+		valueJSONBytes, err := json.Marshal(unboxedValueAsObject)
 		if err != nil {
 			// handle syntax errors specially
 			return append(

--- a/sdks/go/opspec/interpreter/call/op/params/validator.go
+++ b/sdks/go/opspec/interpreter/call/op/params/validator.go
@@ -18,6 +18,7 @@ func Validate(
 	for paramName, paramValue := range params {
 		errs := param.Validate(values[paramName], paramValue)
 		if len(errs) > 0 {
+			fmt.Println("params.validator", paramName, paramValue, errs)
 			paramErrMap[paramName] = errs
 		}
 	}

--- a/test-suite/run/container/object/cmd/array/exit-zero/op.yml
+++ b/test-suite/run/container/object/cmd/array/exit-zero/op.yml
@@ -1,0 +1,9 @@
+name: run/container/object/cmd/array/exit-zero
+run:
+  container:
+    image:
+      ref: alpine
+    cmd:
+      - sh
+      - -ce
+      - exit 0

--- a/test-suite/run/container/object/cmd/array/exit-zero/scenarios.json
+++ b/test-suite/run/container/object/cmd/array/exit-zero/scenarios.json
@@ -1,0 +1,18 @@
+[
+  {
+    "call": {
+      "expect": "success",
+      "scope": {}
+    }
+  },
+  {
+    "interpret": {
+      "expect": "success"
+    }
+  },
+  {
+    "validate": {
+      "expect": "success"
+    }
+  }
+]

--- a/test-suite/run/container/object/cmd/variable/array/exit-zero/op.yml
+++ b/test-suite/run/container/object/cmd/variable/array/exit-zero/op.yml
@@ -1,0 +1,13 @@
+name: run/container/object/cmd/variable/array/exit-zero
+inputs:
+  cmd:
+    array:
+      default:
+        - sh
+        - -ce
+        - exit 0
+run:
+  container:
+    image:
+      ref: alpine
+    cmd: $(cmd)

--- a/test-suite/run/container/object/cmd/variable/array/exit-zero/scenarios.json
+++ b/test-suite/run/container/object/cmd/variable/array/exit-zero/scenarios.json
@@ -1,0 +1,18 @@
+[
+  {
+    "call": {
+      "expect": "success",
+      "scope": {}
+    }
+  },
+  {
+    "interpret": {
+      "expect": "success"
+    }
+  },
+  {
+    "validate": {
+      "expect": "success"
+    }
+  }
+]

--- a/website/docs/reference/opspec/op-directory/op/call/container/index.md
+++ b/website/docs/reference/opspec/op-directory/op/call/container/index.md
@@ -22,7 +22,7 @@ An object defining a container call.
 An [image [object]](image.md) defining the container image run by the call.
 
 ### cmd
-An array of [string initializers](../../../../types/string.md#initialization) defining the path (from [workDir](#workdir)) of the binary to call and it's arguments.
+An [array](../../../../types/array.md) [initializer](../../../../types/array.md#initialization) or [variable-reference [string]](../../variable-reference.md) defining the path (from [workDir](#workdir)) of the binary to call and it's arguments.
 
 > defining cmd overrides any entrypoint and/or cmd defined by the image
 


### PR DESCRIPTION
This PR allows using a variable to define `container.cmd`

It also fixes a bug where simultaneously defining a default plus constraints on an object or array input resulted in a validation error.

closes #1064 