### PR TITLE
download the correct architecture of codecov

### DIFF
--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -19,19 +19,19 @@ inputs:
       description: Home directory of caller; used to access go modules
 run:
   serial:
-    - op:
-        ref: $(../../webapp/.opspec/compile)
-    - op:
-        ref: $(../../cli/.opspec/compile)
-        inputs:
-          HOME:
-          version:
-    - op:
-        ref: $(../test)
-        inputs:
-          dockerSocket:
-          HOME:
-          version:
+    # - op:
+    #     ref: $(../../webapp/.opspec/compile)
+    # - op:
+    #     ref: $(../../cli/.opspec/compile)
+    #     inputs:
+    #       HOME:
+    #       version:
+    # - op:
+    #     ref: $(../test)
+    #     inputs:
+    #       dockerSocket:
+    #       HOME:
+    #       version:
     # report codecoverage
     - serial:        
         - op:
@@ -48,7 +48,14 @@ run:
               - -ce
               - |
                 apk add -U curl
-                curl -Os https://uploader.codecov.io/latest/aarch64/codecov
+                
+                # the backticks around "uname -m" below are less than ideal, but using $(...) broke the op so I don't
+                # think there's another option
+                if [[ `uname -m` == "aarch64" ]]; then
+                  curl -Os https://uploader.codecov.io/latest/aarch64/codecov
+                else
+                  curl -Os https://uploader.codecov.io/latest/alpine/codecov
+                fi
 
                 chmod +x codecov
                 ./codecov

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -19,19 +19,19 @@ inputs:
       description: Home directory of caller; used to access go modules
 run:
   serial:
-    # - op:
-    #     ref: $(../../webapp/.opspec/compile)
-    # - op:
-    #     ref: $(../../cli/.opspec/compile)
-    #     inputs:
-    #       HOME:
-    #       version:
-    # - op:
-    #     ref: $(../test)
-    #     inputs:
-    #       dockerSocket:
-    #       HOME:
-    #       version:
+    - op:
+        ref: $(../../webapp/.opspec/compile)
+    - op:
+        ref: $(../../cli/.opspec/compile)
+        inputs:
+          HOME:
+          version:
+    - op:
+        ref: $(../test)
+        inputs:
+          dockerSocket:
+          HOME:
+          version:
     # report codecoverage
     - serial:        
         - op:
@@ -48,7 +48,7 @@ run:
               - -ce
               - |
                 apk add -U curl
-
+              
                 if [[ `uname -m` == "aarch64" ]]; then
                   curl -Os https://uploader.codecov.io/latest/aarch64/codecov
                 else

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -48,7 +48,7 @@ run:
               - -ce
               - |
                 apk add -U curl
-                curl -Os https://uploader.codecov.io/latest/alpine/codecov
+                curl -Os https://uploader.codecov.io/latest/aarch64/codecov
 
                 chmod +x codecov
                 ./codecov

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -48,9 +48,7 @@ run:
               - -ce
               - |
                 apk add -U curl
-                
-                # the backticks around "uname -m" below are less than ideal, but using $(...) broke the op so I don't
-                # think there's another option
+
                 if [[ `uname -m` == "aarch64" ]]; then
                   curl -Os https://uploader.codecov.io/latest/aarch64/codecov
                 else


### PR DESCRIPTION
# Overview
When I tried to run the release op from main I ran into this error:
```
[59fe15fd] Status: Image is up to date for alpine:latest
[59fe15fd ./.opspec/build] fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/main/aarch64/APKINDEX.tar.gz
[59fe15fd ./.opspec/build] fetch https://dl-cdn.alpinelinux.org/alpine/v3.19/community/aarch64/APKINDEX.tar.gz
[59fe15fd ./.opspec/build] v3.19.1-425-gc85850753c8 [https://dl-cdn.alpinelinux.org/alpine/v3.19/main]
[59fe15fd ./.opspec/build] v3.19.1-423-g66eaf3efa3e [https://dl-cdn.alpinelinux.org/alpine/v3.19/community]
[59fe15fd ./.opspec/build] OK: 22855 distinct packages available
[59fe15fd ./.opspec/build] (1/8) Installing ca-certificates (20240226-r0)
[59fe15fd ./.opspec/build] (2/8) Installing brotli-libs (1.1.0-r1)
[59fe15fd ./.opspec/build] (3/8) Installing c-ares (1.27.0-r0)
[59fe15fd ./.opspec/build] (4/8) Installing libunistring (1.1-r2)
[59fe15fd ./.opspec/build] (5/8) Installing libidn2 (2.3.4-r4)
[59fe15fd ./.opspec/build] (6/8) Installing nghttp2-libs (1.58.0-r0)
[59fe15fd ./.opspec/build] (7/8) Installing libcurl (8.5.0-r0)
[59fe15fd ./.opspec/build] (8/8) Installing curl (8.5.0-r0)
[59fe15fd ./.opspec/build] Executing busybox-1.36.1-r15.trigger
[59fe15fd ./.opspec/build] Executing ca-certificates-20240226-r0.trigger
[59fe15fd ./.opspec/build] OK: 13 MiB in 23 packages
[59fe15fd ./.opspec/build] rosetta error: failed to open elf at /lib/ld-musl-x86_64.so.1
[59fe15fd ./.opspec/build]  Trace/breakpoint trap
[59fe15fd ./.opspec/build] docker.io/library/alpine crashed: nonzero container exit code: 133
[54f6d4f4 ./.opspec/build] op failed: nonzero container exit code: 133
[088e16d7 ./.opspec/build] op failed: nonzero container exit code: 133
[03fdea31 ./.opspec/build] op failed: nonzero container exit code: 133
```

I noticed that alpine was being downloaded using the aarch64 architecture, but we're currently downloading the alpine formatted codecov binary. When I changed the build op to download the aarch64 formatted codecov binary the build op started working on my machine.

## Test Plan
`opctl run build`