### PR TITLE
Check whether Changelog is included in diff, lint changelog on main and in PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
+  check-for-changelog:
+    name: Check for CHANGELOG.md
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install Opctl
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+    - name: Check for CHANGELOG.md
+      run: opctl run check-for-changelog
+
+  lint-changelog:
+    name: lint-changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Install Opctl
+        run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      - name: Run Markdownlint
+        run: opctl run lint
 
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   check-for-changelog:
-    name: Check for CHANGELOG.md
+    name: Check for CHANGELOG.md (PR)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Check out code

--- a/.markdownlint/.markdownlint.json
+++ b/.markdownlint/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "default": true,
+  "MD024": { "siblings_only": true },
+  "MD013": {
+    "//": "Might be nice to decrease this value over time",
+    "line_length": 172,
+    "tables": false
+  },
+  "MD033": { "allowed_elements": ["datatype"] }
+}

--- a/.markdownlint/customRule.js
+++ b/.markdownlint/customRule.js
@@ -1,0 +1,43 @@
+/** @type import("markdownlint").Rule */
+module.exports = {
+  "names": [ "CustomRule/keep-a-changelog-format" ],
+  "description": "CHANGELOG.md must follow the keep-a-changelog format.",
+  "information": new URL("https://keepachangelog.com/en/1.1.0/"),
+  "tags": [ "test", "lint", "changelog" ],
+  "parser": "markdownit",
+  "function": function rule(params, onError) {
+    params.parsers.markdownit.tokens.filter(function filterToken(token) {
+      return token.type === "heading_open";
+    }).forEach(function forToken(heading, index, headings) {
+      if (heading.tag === "h1" && heading.line !== "# Change Log") {
+        // this explicit text is the only valid content for the first heading
+        return onError({
+          "lineNumber": heading.lineNumber,
+          "detail": "First heading should be '# Change Log'.",
+        });
+      } else if (heading.tag === "h2" && !/^## \d\.\d{1,9}\.\d{1,3} - \d{4}-\d{2}-\d{2}$/.test(heading.line)) {
+        // every second heading should be a version number, then a dash and a space, and then a date
+        return onError({
+          "lineNumber": heading.lineNumber,
+          "detail": "Second heading should be a version number and date.",
+        });
+      } else if (heading.tag === "h3") {
+        // every third heading should contain some descriptive information about the changes in the version being described
+        // and should be preceded either by a version heading or another change type heading
+        if (!/^### (Added|Changed|Deprecated|Removed|Fixed)$/.test(heading.line)) {
+          return onError({
+            "lineNumber": heading.lineNumber,
+            "detail": "Third heading should be a change type.",
+          });
+        }
+
+        if (!["h3", "h2"].includes(headings[index - 1].tag)) {
+          return onError({
+            "lineNumber": heading.lineNumber,
+            "detail": "Change type should be preceded by a version number and date.",
+          });
+        }
+      }
+    });
+  }
+};

--- a/.opspec/check-for-changelog/check.sh
+++ b/.opspec/check-for-changelog/check.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+diff=$(git diff origin/main --name-only | grep CHANGELOG.md)
+
+echo $diff
+
+echo "---"
+if [ -z $diff ]; then
+  echo "WARNING: CHANGELOG.md has not been updated. As a result, no new release will be created when this change is pushed to main."
+  echo "Please update CHANGELOG.md with a new version and release notes."
+  exit 1
+else
+  echo "CHANGELOG.md has been updated."
+  exit 0
+fi

--- a/.opspec/check-for-changelog/op.yml
+++ b/.opspec/check-for-changelog/op.yml
@@ -1,0 +1,17 @@
+description: checks if CHANGELOG.md is included in the diff between this branch and main
+name: check-for-changelog
+run:
+  container:
+    image:
+      ref: bitnami/git:2.45.0
+    cmd:
+      - /bin/sh
+      - -c
+      - ./.opspec/check-for-changelog/check.sh
+    workDir: /src
+    dirs:
+      /src: $(../..)
+    files:
+      /root/.gitconfig: |
+        [safe]
+          directory = /src

--- a/.opspec/lint/op.yml
+++ b/.opspec/lint/op.yml
@@ -1,0 +1,13 @@
+description: lints CHANGELOG.md
+name: lint
+run:
+  container:
+    image:
+      ref: ghcr.io/igorshubovych/markdownlint-cli:v0.40.0
+    cmd:
+      - sh
+      - -ce
+      - markdownlint --config .markdownlint/.markdownlint.json CHANGELOG.md --rules .markdownlint/customRule.js
+    dirs:
+      /src: $(../..)
+    workDir: /src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ accordance with
 
 ### Added
 
-- Automatic GPU detection/passthrough for docker runtime 
+- Automatic GPU detection/passthrough for docker runtime
 
 ### Fixed
 
@@ -197,7 +197,7 @@ accordance with
 
 ## 0.1.33 - 2020-04-20
 
-### Fixed 
+### Fixed
 
 - [Nonexistent sub dirs bound to containers aren't sync'd](https://github.com/opctl/opctl/issues/725)
 - [image.ref with multi-variable templated string not working since v0.1.28](https://github.com/opctl/opctl/issues/722)
@@ -447,7 +447,6 @@ accordance with
 - [Param defaults w/ values equal to type default are not defaulted](https://github.com/opctl/opctl/issues/185)
 - [stdOut/stdErr output race condition](https://github.com/opctl/opctl/issues/174)
 - [Unable to run ops w/ containers if using docker 4 windows](https://github.com/opctl/opctl/issues/200)
-
 
 ## 0.1.18 - 2017-03-28
 


### PR DESCRIPTION
# Overview
It would be cool to move opctl to CD. As a first step I'd like to introduce the following changes to CI/CD:
1. Add a job in CI that runs on PRs only. If the changelog is included in the diff, pass. If the changelog is not included then fail (but don't block CI) and print a warning message along the lines of ("WARNING: a new release will not be created when these changes are merged to main unless you add a new entry to CHANGELOG.md")
2. Add a job in CI that lints the current CHANGELOG to make sure it matches the keep-a-changelog format.

In a subsequent PR I'd like to add the following changes:
1. Add a job to the main branch's workflow that runs when CHANGELOG.md was edited. Parse the first version encountered in the file and run the release op using that as the new version. The release will be created as a prerelease and will not be marked as latest, so a maintainer will need to manually update the release to mark it as latest and remove the prerelease tag when the change is good to go

## Gotchas
1. We need to sort out what docker creds to add to this repo's secrets so that the new op I'm adding can talk to dockerhub. Maybe we can make a service account on dockerhub for the opctl organization?
2. There are two potential issues on Codacy that were introduced by this PR, and I don't think they're actually issues based on the input that will be provided to the code that uses the regexes. You can see the issues here https://app.codacy.com/gh/opctl/opctl/pull-requests/1098/issues