### PR TITLE
Create a release whenever changes are merged to main that include an updated CHANGELOG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,18 @@ jobs:
       run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
 
     - run: opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} -a version=0.0.1 build
+
+  create-release:
+    name: Create Draft Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [build, lint-changelog]
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+    - name: Install Opctl
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+    - name: Create Release for latest version
+      id: create_release
+      run: |
+        opctl run -a github='{"username":"${{ github.actor }}", "accessToken": "${{ github.token }}"}' release

--- a/.markdownlint/customRule.js
+++ b/.markdownlint/customRule.js
@@ -15,7 +15,7 @@ module.exports = {
           "lineNumber": heading.lineNumber,
           "detail": "First heading should be '# Change Log'.",
         });
-      } else if (heading.tag === "h2" && !/^## \d\.\d{1,9}\.\d{1,3} - \d{4}-\d{2}-\d{2}$/.test(heading.line)) {
+      } else if (heading.tag === "h2" && !/^## \d\.\d{1,9}\.\d{1,3}-?[A-Za-z0-9]{0,} - \d{4}-\d{2}-\d{2}$/.test(heading.line)) {
         // every second heading should be a version number, then a dash and a space, and then a date
         return onError({
           "lineNumber": heading.lineNumber,

--- a/.opspec/release/check.sh
+++ b/.opspec/release/check.sh
@@ -7,8 +7,8 @@ apk add --update docker
 # only continue with release if tag doesn't exist
 if docker pull ghcr.io/opctl/opctl:${version}-dind; then
   echo "Opctl Image for version '${version}' already exists"
-  echo true > /alreadyPublished
+  echo -n true > /alreadyPublished
 else
   echo "Image does not exist, proceeding with release..."
-  echo false > /alreadyPublished
+  echo -n false > /alreadyPublished
 fi

--- a/.opspec/release/op.yml
+++ b/.opspec/release/op.yml
@@ -25,10 +25,6 @@ inputs:
   HOME:
     dir:
       description: Home directory of caller; used to access go modules
-  version:
-    string:
-      constraints: { format: semver }
-      description: version of opctl being released
 run:
   serial:
     - op:
@@ -44,7 +40,7 @@ run:
     - container:
         image: { ref: alpine:3.20 }
         envVars:
-          version: $(version)
+          version: $(latestVersion)
         cmd:
           - sh
           - -c

--- a/.opspec/release/to-github/op.yml
+++ b/.opspec/release/to-github/op.yml
@@ -15,9 +15,10 @@ inputs:
         required: [accessToken, username]
       description: configuration required to interact w/ github
   version:
-    string:
-      constraints: { format: semver }
-      description: version of opctl being released
+      string:
+        constraints:
+          format: semver
+        description: the version to release to GitHub
 run:
   serial:
     # create github release
@@ -27,6 +28,20 @@ run:
           dotGitDir: $(../../../.git)
         outputs:
           commit:
+    - container:
+        image:
+          ref: alpine
+        cmd:
+          - sh
+          - -c
+          - |
+            if echo $(version) | grep -q -E '[0-9]+.[0-9]+.[0-9]+-[A-Za-z0-9]{1,}'; then
+              echo -n true > /prerelease
+            else
+              echo -n false > /prerelease
+            fi
+        files:
+          /prerelease: $(prerelease)
     - op:
         ref: github.com/opspec-pkgs/github.release.create#2.0.0
         inputs:
@@ -37,6 +52,7 @@ run:
           repo: opctl
           tag: v$(version)
           name: v$(version)
+          isPrerelease: $(prerelease)
         outputs:
           id: $(releaseId)
     - parallelLoop:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,19 @@ accordance with
 
 ### Added
 
-Create a prerelease whenever the CHANGELOG is changed on a merge to main
+Create a prerelease whenever the CHANGELOG is changed on a merge to main. No application code changes
 
 ## 0.1.53 - 2024-04-18
 
 ### Fixed
+- A few dependency updates
+  - in the Golang SDK the only breaking upgrade is Docker v23 -> v25.0.3+incompatible
+  - in the JS SDK nock (a devDependency) was updated from 9 -> 13.
+  - in the JS SDK react-ace was updated from 9 -> 11
 
-Dependency updates
+### Removed
+- Deleted the React SDK because it is unused
+
 
 ## 0.1.52 - 2023-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ accordance with
 
 ### Added
 
-Create a prerelease whenever the CHANGELOG is changed on a merge to main. No application code changes
+Create a prerelease whenever the CHANGELOG is changed on a merge to main. No
+application code changes
 
 ## 0.1.53 - 2024-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,15 @@ Create a prerelease whenever the CHANGELOG is changed on a merge to main. No app
 ## 0.1.53 - 2024-04-18
 
 ### Fixed
+
 - A few dependency updates
   - in the Golang SDK the only breaking upgrade is Docker v23 -> v25.0.3+incompatible
   - in the JS SDK nock (a devDependency) was updated from 9 -> 13.
   - in the JS SDK react-ace was updated from 9 -> 11
 
 ### Removed
-- Deleted the React SDK because it is unused
 
+- Deleted the React SDK because it is unused
 
 ## 0.1.52 - 2023-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## 0.1.54-pre - 2024-05-23
+
+### Added
+
+Create a prerelease whenever the CHANGELOG is changed on a merge to main
+
+## 0.1.53 - 2024-04-18
+
+### Fixed
+
+Dependency updates
+
 ## 0.1.52 - 2023-06-06
 
 ### Fixed


### PR DESCRIPTION
# Overview
Create a release on merge to main if CHANGELOG was updated to add a new version

## Testing
I ran the release op from my laptop and you can see that a new release was created and new containers were pushed to ghcr