### PR TITLE
do not set default version in ops

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,4 +55,4 @@ jobs:
     - name: Install Opctl
       run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
 
-    - run: opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} build
+    - run: opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} -a version=0.0.1 build

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -11,7 +11,6 @@ inputs:
       default: main
   version:
     string:
-      default: 0.0.0
       constraints:
         format: semver
   HOME:

--- a/.opspec/build/op.yml
+++ b/.opspec/build/op.yml
@@ -30,7 +30,6 @@ run:
         inputs:
           dockerSocket:
           HOME:
-          version:
     # report codecoverage
     - serial:        
         - op:

--- a/.opspec/release/to-github/op.yml
+++ b/.opspec/release/to-github/op.yml
@@ -28,7 +28,7 @@ run:
         outputs:
           commit:
     - op:
-        ref: github.com/opspec-pkgs/github.release.create#1.2.0
+        ref: github.com/opspec-pkgs/github.release.create#2.0.0
         inputs:
           commitish: $(commit)
           loginPassword: $(github.accessToken)

--- a/.opspec/test/op.yml
+++ b/.opspec/test/op.yml
@@ -7,11 +7,7 @@ inputs:
   HOME:
     dir:
       description: Home directory of caller; used to access go modules
-  version:
-    string:
-      default: 0.0.0
-      constraints:
-        format: semver
+
 run:
   parallel:
     # api tests

--- a/cli/.opspec/compile/op.yml
+++ b/cli/.opspec/compile/op.yml
@@ -3,7 +3,6 @@ name: compile
 inputs:
   version:
     string:
-      default: 0.0.1
       constraints:
         format: semver
   HOME:


### PR DESCRIPTION
# Overview
Prior to this change, when someone runs the `compile` op in the CLI directory, their binary will be built with a version `0.0.1`. That's not desirable because new maintainers can very easily miss that they're expected to provide a new version when they compile the opctl CLI 😅. This change:
1. removes all default values for `version` inputs in ops
2. removes `version` as an input from the test op because that appears to have been introduced as a copy pasta (it's not used in the op at all)
3. Updates the `github.release.create` op to version 2.0.0 from 1.2.0

## Testing
1. I expect CI to continue to pass
2. Locally I ran the `compile` op in the CLI directory and verified that the built binary has a version that I expect.