### PR TITLE
Fix long time to resolve if op does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## 0.1.54 - 2024-09-04
+
+### Added
+
+- Fix long time to resolve non-existent op
+
 ## 0.1.54-pre - 2024-05-23
 
 ### Added
@@ -226,7 +232,7 @@ application code changes
 
 ### Added
 
-- [Prefix opctl managed container names with opctl_](https://github.com/opctl/opctl/issues/735)
+- [Prefix opctl managed container names with opctl\_](https://github.com/opctl/opctl/issues/735)
 
 ### Fixed
 
@@ -510,9 +516,9 @@ application code changes
 
 ```yaml
 paramName:
-      string:
-        description: ...
-        # and so on...
+  string:
+    description: ...
+    # and so on...
 ```
 
 ### Removed
@@ -545,7 +551,7 @@ paramName:
 
 ### Fixed
 
-- [Emitted ContainerStd*WrittenToEvent.Data Incomplete](https://github.com/opctl/opctl/issues/32)
+- [Emitted ContainerStd\*WrittenToEvent.Data Incomplete](https://github.com/opctl/opctl/issues/32)
 
 ## 0.1.8 - 2016-09-09
 

--- a/cli/internal/opgraph/callgraph.go
+++ b/cli/internal/opgraph/callgraph.go
@@ -32,7 +32,7 @@ func newCallGraphNode(call *model.Call, timestamp time.Time) *callGraphNode {
 	}
 }
 
-var errNotFoundInGraph = errors.New("not found in graph")
+var errNotFoundInGraph = fmt.Errorf("%w in graph", model.ErrDataRefResolution{})
 
 const skippedState = "skipped"
 

--- a/sdks/go/data/fs/fs.go
+++ b/sdks/go/data/fs/fs.go
@@ -4,7 +4,6 @@ package fs
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,7 +37,7 @@ func (fp _fs) TryResolve(
 	if filepath.IsAbs(dataRef) {
 		if _, err := os.Stat(dataRef); err != nil {
 			if os.IsNotExist(err) {
-				return nil, fmt.Errorf("path %s not found", dataRef)
+				return nil, fmt.Errorf("%w: path \"%s\"", model.ErrDataRefResolution{}, dataRef)
 			}
 			return nil, err
 		}
@@ -48,7 +47,7 @@ func (fp _fs) TryResolve(
 	var aggregateErr aggregateError.ErrAggregate
 
 	if len(fp.basePaths) == 0 {
-		return nil, errors.New("skipped")
+		return nil, model.ErrDataSkipped{}
 	}
 
 	for _, basePath := range fp.basePaths {
@@ -60,7 +59,7 @@ func (fp _fs) TryResolve(
 			// don't return not found errors, instead continue checking other base paths
 			return nil, err
 		}
-		aggregateErr.AddError(fmt.Errorf("path %s not found", testPath))
+		aggregateErr.AddError(fmt.Errorf("%w: path \"%s\"", model.ErrDataRefResolution{}, testPath))
 	}
 
 	return nil, aggregateErr

--- a/sdks/go/data/git/clone.go
+++ b/sdks/go/data/git/clone.go
@@ -29,7 +29,7 @@ func Clone(
 
 	parsedPkgRef, err := parseRef(dataRef)
 	if err != nil {
-		return fmt.Errorf("invalid git ref: %w", err)
+		return fmt.Errorf("%w: %w", model.ErrDataGitInvalidRef{}, err)
 	}
 
 	opPath := parsedPkgRef.ToPath(path)
@@ -54,7 +54,7 @@ func Clone(
 		cloneOptions,
 	); err != nil {
 		if _, ok := err.(git.NoMatchingRefSpecError); ok {
-			return fmt.Errorf("version \"%s\" not found", parsedPkgRef.Version)
+			return fmt.Errorf("%w: version \"%s\"", parsedPkgRef.Version, model.ErrDataRefResolution{})
 		}
 		if errors.Is(err, transport.ErrAuthenticationRequired) {
 			return model.ErrDataProviderAuthentication{}

--- a/sdks/go/data/git/clone.go
+++ b/sdks/go/data/git/clone.go
@@ -54,7 +54,7 @@ func Clone(
 		cloneOptions,
 	); err != nil {
 		if _, ok := err.(git.NoMatchingRefSpecError); ok {
-			return fmt.Errorf("%w: version \"%s\"", parsedPkgRef.Version, model.ErrDataRefResolution{})
+			return fmt.Errorf("%w: version \"%s\"", model.ErrDataRefResolution{}, parsedPkgRef.Version)
 		}
 		if errors.Is(err, transport.ErrAuthenticationRequired) {
 			return model.ErrDataProviderAuthentication{}

--- a/sdks/go/data/git/parseRef.go
+++ b/sdks/go/data/git/parseRef.go
@@ -1,11 +1,12 @@
 package git
 
 import (
-	"errors"
 	"net/url"
 	"path"
 	"path/filepath"
 	"strings"
+
+	"github.com/opctl/opctl/sdks/go/model"
 )
 
 // parseRef string to object
@@ -20,7 +21,7 @@ func parseRef(
 	// fragment MAY be in format: SEM_VER/OP_PATH
 	version := strings.SplitN(refURI.Fragment, "/", 2)[0]
 	if version == "" {
-		return nil, errors.New("missing version")
+		return nil, model.ErrDataMissingVersion{}
 	}
 
 	return &ref{

--- a/sdks/go/data/resolve.go
+++ b/sdks/go/data/resolve.go
@@ -32,5 +32,5 @@ func Resolve(
 		}
 	}
 
-	return nil, fmt.Errorf("unable to resolve op '%s': %w", dataRef, agg)
+	return nil, fmt.Errorf("%w op \"%s\": %w", model.ErrDataUnableToResolve{}, dataRef, agg)
 }

--- a/sdks/go/model/errors.go
+++ b/sdks/go/model/errors.go
@@ -1,6 +1,8 @@
 package model
 
-import "errors"
+import (
+	"errors"
+)
 
 // ErrDataProviderAuthentication conveys data pull failed due to authentication
 type ErrDataProviderAuthentication struct{}
@@ -19,8 +21,36 @@ func (ErrDataProviderAuthorization) Error() string {
 // ErrDataRefResolution conveys no such data could be found
 type ErrDataRefResolution struct{}
 
-func (ErrDataRefResolution) Error() string {
+func (e ErrDataRefResolution) Error() string {
 	return "not found"
+}
+
+// ErrDataUnableToResolve conveys unable to resolve data
+type ErrDataUnableToResolve struct{}
+
+func (e ErrDataUnableToResolve) Error() string {
+	return "unable to resolve"
+}
+
+// ErrDataGitInvalidRef conveys invalid git ref specified
+type ErrDataGitInvalidRef struct{}
+
+func (e ErrDataGitInvalidRef) Error() string {
+	return "invalid git ref"
+}
+
+// ErrDataMissingVersion conveys missing version
+type ErrDataMissingVersion struct{}
+
+func (e ErrDataMissingVersion) Error() string {
+	return "missing version"
+}
+
+// ErrDataSkipped conveys data was skipped
+type ErrDataSkipped struct{}
+
+func (e ErrDataSkipped) Error() string {
+	return "skipped"
 }
 
 // IsAuthError returns true if this is an authorization or authentication error

--- a/sdks/go/node/api/handler/data/ref/handler.go
+++ b/sdks/go/node/api/handler/data/ref/handler.go
@@ -72,8 +72,10 @@ func (hdlr _handler) Handle(
 			} else if errors.Is(err, model.ErrDataProviderAuthorization{}) {
 				hdlr.setWWWAuthenticateHeader(dataRef, httpResp.Header())
 				status = http.StatusForbidden
-			} else if errors.Is(err, model.ErrDataRefResolution{}) {
+			} else if errors.Is(err, model.ErrDataRefResolution{}) || errors.Is(err, model.ErrDataUnableToResolve{}) {
 				status = http.StatusNotFound
+			} else if errors.Is(err, model.ErrDataMissingVersion{}) || errors.Is(err, model.ErrDataGitInvalidRef{}) {
+				status = http.StatusBadRequest
 			} else {
 				status = http.StatusInternalServerError
 			}


### PR DESCRIPTION
### Repro
Type `opctl run aisdjufbhiaudbh` in a repo and observe it take a very long time to figure out that the op doesn’t exist.

### Problem:
opctl takes ~1.5 mins to resolve ops that do not exist. It takes this long because `httpClient` is using https://github.com/sethgrid/pester that will retry on certain error codes. The node's `/api/data/{ref}` endpoint returns 500 error if we don't detect the error. This makes it so that it retries ~90 times before it fails.

### Solution:
- Use additional custom errors to detect common errors when attempting to resolve ops through node's `/api/data/{ref}` endpoint
- Return http status error codes that match the result when trying to resolve node's api/data so that retry doesn't occur
- More consistent error formatting