### PR TITLE
Ensure permissions on opctl data can't be broken by umask

### DIFF
--- a/cli/nodeCreate.go
+++ b/cli/nodeCreate.go
@@ -57,14 +57,19 @@ func nodeCreate(
 				cliColorer.Info(fmt.Sprintf("opctl API listening at %s", nodeConfig.APIListenAddress)),
 			)
 
+			c, err := core.New(
+				ctx,
+				containerRT,
+				dataDir.Path(),
+			)
+			if err != nil {
+				return err
+			}
+
 			return api.Listen(
 				ctx,
 				nodeConfig.APIListenAddress,
-				core.New(
-					ctx,
-					containerRT,
-					dataDir.Path(),
-				),
+				c,
 			)
 		},
 	)

--- a/sdks/go/node/api/listen.go
+++ b/sdks/go/node/api/listen.go
@@ -52,7 +52,8 @@ func Listen(
 
 	go func() {
 		<-ctx.Done()
-		ctx, _ := context.WithTimeout(ctx, 5*time.Second)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
 
 		// little hammer
 		apiServer.Shutdown(ctx)

--- a/sdks/go/node/core.go
+++ b/sdks/go/node/core.go
@@ -23,12 +23,11 @@ func New(
 	ctx context.Context,
 	containerRuntime containerruntime.ContainerRuntime,
 	dataDirPath string,
-) Core {
+) (Core, error) {
 
 	eventDbPath := path.Join(dataDirPath, "dcg", "events")
-	err := os.MkdirAll(eventDbPath, 0700)
-	if err != nil {
-		panic(err)
+	if err := os.MkdirAll(eventDbPath, 0770); err != nil {
+		return nil, err
 	}
 
 	// per badger README.MD#FAQ "maximizes throughput"
@@ -53,7 +52,7 @@ func New(
 			}
 		}
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 	}
 
@@ -114,7 +113,7 @@ func New(
 		),
 		pubSub:     pubSub,
 		stateStore: stateStore,
-	}
+	}, nil
 }
 
 // core is an Node that supports running ops directly on the host

--- a/sdks/go/node/core_test.go
+++ b/sdks/go/node/core_test.go
@@ -19,13 +19,14 @@ var _ = Context("core", func() {
 			}
 
 			/* act/assert */
-			Expect(
-				New(
-					context.Background(),
-					new(FakeContainerRuntime),
-					dataDir,
-				),
-			).To(Not(BeNil()))
+			actual, actualErr := New(
+				context.Background(),
+				new(FakeContainerRuntime),
+				dataDir,
+			)
+
+			Expect(actualErr).To(BeNil())
+			Expect(actual).To(Not(BeNil()))
 		})
 	})
 })

--- a/sdks/go/node/datadir/datadir.go
+++ b/sdks/go/node/datadir/datadir.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/rogpeppe/go-internal/lockedfile"
+	"golang.org/x/sys/unix"
 )
 
 // DataDir is an interface exposing the functionality we require in conjunction with our "data dir".
@@ -21,10 +22,10 @@ type DataDir interface {
 func ensureExists(
 	resolvedDataDirPath string,
 ) error {
-	if err := os.MkdirAll(resolvedDataDirPath, 0775|os.ModeSetgid); err != nil {
-		return err
-	}
-	return nil
+	// don't de-privilege group
+	unix.Umask(0002)
+
+	return os.MkdirAll(resolvedDataDirPath, 0770|os.ModeSetgid)
 }
 
 // New returns an initialized data dir instance

--- a/sdks/go/opspec/interpreter/call/container/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/interpret.go
@@ -43,7 +43,7 @@ func Interpret(
 		containerID,
 		"fs",
 	)
-	if err := os.MkdirAll(scratchDirPath, 0700); err != nil {
+	if err := os.MkdirAll(scratchDirPath, 0770); err != nil {
 		return nil, err
 	}
 

--- a/sdks/go/opspec/interpreter/reference/direntry/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/direntry/interpret.go
@@ -34,7 +34,7 @@ func Interpret(
 	} else if opts != nil && os.IsNotExist(err) {
 
 		if *opts == "Dir" {
-			err := os.MkdirAll(valuePath, 0700)
+			err := os.MkdirAll(valuePath, 0770)
 			if err != nil {
 				return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 			}
@@ -43,7 +43,7 @@ func Interpret(
 		}
 
 		// handle file ref
-		err := os.MkdirAll(filepath.Dir(valuePath), 0700)
+		err := os.MkdirAll(filepath.Dir(valuePath), 0770)
 		if err != nil {
 			return "", nil, fmt.Errorf("unable to interpret '%v' as dir entry ref: %w", ref, err)
 		}

--- a/sdks/go/opspec/interpreter/reference/interpret.go
+++ b/sdks/go/opspec/interpreter/reference/interpret.go
@@ -162,10 +162,10 @@ func getRootValue(
 
 		switch opts.Type {
 		case "Dir":
-			os.MkdirAll(fsPath, 0700)
+			os.MkdirAll(fsPath, 0770)
 			return &model.Value{Dir: &fsPath}, "", nil
 		case "File":
-			os.MkdirAll(filepath.Dir(fsPath), 0700)
+			os.MkdirAll(filepath.Dir(fsPath), 0770)
 			os.Create(fsPath)
 			return &model.Value{File: &fsPath}, "", nil
 		}


### PR DESCRIPTION
This PR fixes an edge case encountered in testing on OSX following #1112 where variables were initialized by mounting to container files/dirs would error with `invalid mount config [...] permission denied`.

Upon investigation it was found that:
On Docker for Mac, the file sync between VM and host doesn't have access to `root` (UID=0) owned files unless the owning group also has access. 

Additionally, by default umask is `022` so this was leading to no owning group write access and the error scenario. 