### PR TITLE
Fix release op

### DIFF
--- a/.opspec/release/op.yml
+++ b/.opspec/release/op.yml
@@ -29,6 +29,8 @@ run:
   serial:
     - op:
         ref: $(../changelog/getLatestRelease)
+        inputs:
+          HOME:
         outputs:
           latestRelease:
     - op:


### PR DESCRIPTION
Need to pass HOME to the getLatestRelease op since it requires it. Wasn't caught in testing pre-merge because the only way to test is to run a release (which happens post merge) ; ). 