### PR TITLE
Fix changelog/getLatestRelease op output casing

### DIFF
--- a/.opspec/changelog/getLatestRelease/main.go
+++ b/.opspec/changelog/getLatestRelease/main.go
@@ -10,7 +10,7 @@ import (
 
 type Release struct {
 	Description  string `json:"description"`
-	IsPrerelease bool   `json:"isPreRelease"`
+	IsPrerelease bool   `json:"isPrerelease"`
 	Version      string `json:"version"`
 }
 


### PR DESCRIPTION
Casing of changelog/getLatestRelease ops latestRelease.isPrerelease was not matching what was expected.

As with prior PR, this wasn't caught in testing pre-merge because the only way to test is to run a release (which happens post merge) ; ).