### PR TITLE
Release prep; Fix container dns names on linux & support passwordless sudo for node startup

### DIFF
--- a/.opspec/changelog/getLatestRelease/go.mod
+++ b/.opspec/changelog/getLatestRelease/go.mod
@@ -3,12 +3,13 @@ module parseLatestVersion
 go 1.23.2
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/anton-yurchenko/go-changelog v1.1.0
-	golang.org/x/mod v0.12.0
 )
 
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/afero v1.9.5 // indirect
+	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/.opspec/changelog/getLatestRelease/go.sum
+++ b/.opspec/changelog/getLatestRelease/go.sum
@@ -38,6 +38,8 @@ cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3f
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
+github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/anton-yurchenko/go-changelog v1.1.0 h1:cMxJSgImWYyGNYHhOymx9hGLKpAWdx9vk6sHvvrFpj4=
 github.com/anton-yurchenko/go-changelog v1.1.0/go.mod h1:rCeTvjDIDiCK4OQfI1G+MQ0JWptLCXG2o2UmHke8rlo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/.opspec/changelog/getLatestRelease/main.go
+++ b/.opspec/changelog/getLatestRelease/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"encoding/json"
-	"golang.org/x/mod/semver"
 	"os"
+
+	"github.com/Masterminds/semver/v3"
 
 	changelog "github.com/anton-yurchenko/go-changelog"
 )
@@ -26,11 +27,15 @@ func main() {
 	}
 
 	latestRelease := c.Releases[0]
+	sv, err := semver.NewVersion(*latestRelease.Version)
+	if err != nil {
+		panic(err)
+	}
 
 	lateReleaseJSON, err := json.Marshal(
 		Release{
 			Description:  latestRelease.Changes.ToString(),
-			IsPrerelease: semver.Prerelease(*latestRelease.Version) != "",
+			IsPrerelease: sv.Prerelease() != "",
 			Version:      *latestRelease.Version,
 		},
 	)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.56] - 2024-11-11
+
+### Added
+
+- Access containers by their name from opctl nodes
+
+### Deprecated
+
+- `container.ports`; access containers by name instead
+
 ## [0.1.56-alpha.1] - 2024-11-08
 
 ### Added

--- a/sdks/go/node/dns/internal/resolvercfg/apply_linux.go
+++ b/sdks/go/node/dns/internal/resolvercfg/apply_linux.go
@@ -35,7 +35,7 @@ func Apply(
 	)
 
 	rcString := string(rc)
-	if strings.HasPrefix(rcString, nsPrefix) {
+	if !strings.HasPrefix(rcString, nsPrefix) {
 		return os.WriteFile(
 			etcResolvConfPath,
 			[]byte(fmt.Sprintf(


### PR DESCRIPTION
This PR addresses two last touchups before release 0.1.56 namely:
- not requiring explicitly using sudo to start a node if the caller has passwordless sudo enabled
- address a regression for the linux os where container dns names wouldn't work