### PR TITLE
Expose rate limiting errors from gpu enablement check

### DIFF
--- a/.markdownlint/customRule.js
+++ b/.markdownlint/customRule.js
@@ -15,11 +15,10 @@ module.exports = {
           "lineNumber": heading.lineNumber,
           "detail": "First heading should be '# Changelog'.",
         });
-      } else if (heading.tag === "h2" && !/^## \[(\d\.\d{1,9}\.\d{1,3}(-[.A-Za-z0-9]+)?)|Unreleased\]| - \d{4}-\d{2}-\d{2}$/.test(heading.line)) {
-        // every second heading should be a version number, then a dash and a space, and then a date
+      } else if (heading.tag === "h2" && !/^## (\[\d\.\d{1,9}\.\d{1,3}(-[.A-Za-z0-9]+)?\] - \d{4}-\d{2}-\d{2})|(\[Unreleased\])$/.test(heading.line)) {
         return onError({
           "lineNumber": heading.lineNumber,
-          "detail": "Second heading should be a version number and date.",
+          "detail": "Second heading should be a '[version number] - date' or '[Unreleased]'.",
         });
       } else if (heading.tag === "h3") {
         // every third heading should contain some descriptive information about the changes in the version being described

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Fixed
+
+- Rate limit errors surfacing as "image not found" errors
+
 ## [0.1.56] - 2024-11-11
 
 ### Added
@@ -274,7 +280,7 @@ accordance with
 
 - [Named calls and needs](https://github.com/opctl/opctl/issues/643)
 
-## 0.1.29 - 2020-04-02
+## [0.1.29] - 2020-04-02
 
 ### Fixed
 

--- a/cli/.opspec/test/e2e/op.yml
+++ b/cli/.opspec/test/e2e/op.yml
@@ -38,4 +38,4 @@ run:
                   /cmd.sh:
                   /usr/local/bin/opctl: $(../../../opctl-linux-amd64)
                 image:
-                  ref: docker:20.10.17-dind
+                  ref: docker:27.3-dind

--- a/sdks/go/node/containerruntime/docker/isGpuSupported.go
+++ b/sdks/go/node/containerruntime/docker/isGpuSupported.go
@@ -54,6 +54,9 @@ func isGpuSupported(
 		"",
 		noOpEventPublisher{},
 	)
+	if err != nil {
+		return false, err
+	}
 
 	createResponse, err := dockerClient.ContainerCreate(
 		ctx,


### PR DESCRIPTION
This PR passes through an error condition that was being ignored while testing if the machine is gpu enabled. Generally the only way this error occurs is during rate limiting when the image is not cached, which is a rather unlikely edge case, but are hitting it ourselves in e2e tests due to no not caching any images across test scenarios. 