### PR TITLE
Fast follow to address issues reported in 0.1.56

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     - name: Check for CHANGELOG.md
       run: opctl run changelog/find-in-diff
 
@@ -28,7 +28,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Install Opctl
-        run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+        run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
       - name: Run Markdownlint
         run: opctl run changelog/lint
 
@@ -53,7 +53,7 @@ jobs:
       run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF})"
 
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     
       # the release op runs the build step, so only run build on PRs
     - run: opctl run -a gitBranch=${{ steps.branch_name_push.outputs.branch }}${{ steps.branch_name_pr.outputs.branch }} -a version=0.0.1 build
@@ -68,7 +68,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     - name: Create Release for latest version
       id: create_release
       run: |

--- a/.markdownlint/customRule.js
+++ b/.markdownlint/customRule.js
@@ -15,11 +15,10 @@ module.exports = {
           "lineNumber": heading.lineNumber,
           "detail": "First heading should be '# Changelog'.",
         });
-      } else if (heading.tag === "h2" && !/^## \[(\d\.\d{1,9}\.\d{1,3}(-[.A-Za-z0-9]+)?)|Unreleased\]| - \d{4}-\d{2}-\d{2}$/.test(heading.line)) {
-        // every second heading should be a version number, then a dash and a space, and then a date
+      } else if (heading.tag === "h2" && !/^## (\[\d\.\d{1,9}\.\d{1,3}(-[.A-Za-z0-9]+)?\] - \d{4}-\d{2}-\d{2})|(\[Unreleased\])$/.test(heading.line)) {
         return onError({
           "lineNumber": heading.lineNumber,
-          "detail": "Second heading should be a version number and date.",
+          "detail": "Second heading should be a '[version number] - date' or '[Unreleased]'.",
         });
       } else if (heading.tag === "h3") {
         // every third heading should contain some descriptive information about the changes in the version being described

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.57] - 2024-11-12
+
+### Changed
+
+- Don't log "not found in graph" to logs (noisy without value)
+
+### Fixed
+
+- Fix 'opctl node kill' panics if you've never run an op
+- Rate limit errors surfacing as "image not found" errors
+- Fixed file initialization results in incorrect (empty) file data
+
 ## [0.1.56] - 2024-11-11
 
 ### Added
@@ -274,7 +286,7 @@ accordance with
 
 - [Named calls and needs](https://github.com/opctl/opctl/issues/643)
 
-## 0.1.29 - 2020-04-02
+## [0.1.29] - 2020-04-02
 
 ### Fixed
 

--- a/cli/internal/opgraph/callgraph.go
+++ b/cli/internal/opgraph/callgraph.go
@@ -32,8 +32,6 @@ func newCallGraphNode(call *model.Call, timestamp time.Time) *callGraphNode {
 	}
 }
 
-var errNotFoundInGraph = fmt.Errorf("%w in graph", model.ErrDataRefResolution{})
-
 const skippedState = "skipped"
 
 func (n *callGraphNode) insert(call *model.Call, startTime time.Time, initialState string) error {
@@ -55,7 +53,9 @@ func (n *callGraphNode) insert(call *model.Call, startTime time.Time, initialSta
 			return nil
 		}
 	}
-	return errNotFoundInGraph
+
+	// received unexpected call; return empty error since we'll just ignore it
+	return errors.New("")
 }
 
 func (n *callGraphNode) find(call *model.Call) *callGraphNode {

--- a/sdks/go/internal/unsudo/createFile.go
+++ b/sdks/go/internal/unsudo/createFile.go
@@ -14,7 +14,7 @@ func CreateFile(
 		return err
 	}
 
-	if err := os.WriteFile(fsPath, []byte{}, 0700); err != nil {
+	if err := os.WriteFile(fsPath, data, 0700); err != nil {
 		return err
 	}
 

--- a/sdks/go/node/containerruntime/docker/isGpuSupported.go
+++ b/sdks/go/node/containerruntime/docker/isGpuSupported.go
@@ -42,7 +42,7 @@ func isGpuSupported(
 
 	imageRef := "alpine"
 
-	err := pullImage(
+	if err := pullImage(
 		context.Background(),
 		&model.ContainerCall{
 			Image: &model.ContainerCallImage{
@@ -53,7 +53,9 @@ func isGpuSupported(
 		dockerClient,
 		"",
 		noOpEventPublisher{},
-	)
+	); err != nil {
+		return false, err
+	}
 
 	createResponse, err := dockerClient.ContainerCreate(
 		ctx,

--- a/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
+++ b/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
@@ -23,6 +23,10 @@ func Delete(
 				return err
 			}
 
+			if d == nil {
+				return nil
+			}
+
 			if strings.HasPrefix(
 				d.Name(),
 				resolverPrefix,

--- a/website/docs/reference/opspec/op-directory/op/call/container/index.md
+++ b/website/docs/reference/opspec/op-directory/op/call/container/index.md
@@ -14,7 +14,6 @@ An object defining a container call.
   - [envVars](#envvars)
   - [files](#files)
   - [name](#name)
-  - [ports](#ports)
   - [sockets](#sockets)
   - [workDir](#workdir)
 
@@ -50,14 +49,9 @@ An object for which each key is an absolute path in the container and each value
 |[file initializer](../../../../types/file.md#initialization)|Evaluate and mount|
 
 ### name
-A [string initializer](../../../../types/string.md#initialization) defining a name by which the container can be resolved on the opctl network.
+A [string initializer](../../../../types/string.md#initialization) defining a name by which the container can be reached by other opctl containers and opctl host nodes.
 
 > if multiple containers are given the same name, network requests will be distributed (load balanced) across them. 
-
-### ports
-An object defining container ports exposed on the opctl host where:
-- each key is a container port or range of ports (optionally including protocol) matching `[0-9]+(-[0-9]+)?(tcp|udp)`
-- each value is a corresponding opctl host port or range of ports matching `[0-9]+(-[0-9]+)?`
 
 ### sockets
 An object for which each key is an absolute path in the container and and each value is a [socket](../../../../types/socket.md) [variable-reference [string]](../../variable-reference.md) to mount. 

--- a/website/docs/training/containers/container-networking.md
+++ b/website/docs/training/containers/container-networking.md
@@ -14,14 +14,22 @@ If multiple containers have the same [name](../../reference/opspec/op-directory/
     ```yaml
     name: containerNetworking
     run:
-      parallel:
+    parallel:
         - container:
             image: { ref: nginx }
             # some syntactically valid hostname
             name: nginx.demo.wow
         - container:
-            image: { ref: alpine/curl }
-            cmd: [ping, nginx.demo.wow]
+            image: { ref: alpine }
+            cmd:
+            - sh
+            - -ce
+            - |
+                # wait up
+                sleep 1; until ping -c1 nginx.demo.wow >/dev/null 2>&1; do :; done
+
+                # ping forever
+                ping nginx.demo.wow
     ```
 
 1. Observe the second container succeeds in `ping`ing the `nginx.demo.wow` container.


### PR DESCRIPTION
This PR is a fast follow to address several issues reported after releasing  0.1.56, namely:

- Fix 'opctl node kill' before you've ever run an op'
- Fix: Rate limit errors surfacing as "image not found" errors
- Don't log "not found in graph" to logs (noisy without value)
- Fixed file initialization results in incorrect (empty) file data