### PR TITLE
Fix release notes with JSON special characters break release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     - name: Check for CHANGELOG.md
       run: opctl run changelog/find-in-diff
 
@@ -28,7 +28,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Install Opctl
-        run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+        run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
       - name: Run Markdownlint
         run: opctl run changelog/lint
 
@@ -40,7 +40,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     - name: Compile
       run: opctl run -a version=0.0.0 compile
     - name: Test
@@ -55,7 +55,7 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v4
     - name: Install Opctl
-      run: curl -L https://github.com/opctl/opctl/releases/download/v0.1.55/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
+      run: curl -L https://github.com/opctl/opctl/releases/latest/download/opctl-linux-amd64.tgz | sudo tar -xzv -C /usr/local/bin
     - name: Create release from latest changelog entry
       id: create_release
       run: opctl run -a github='{"username":"${{ github.actor }}","accessToken":"${{ github.token }}"}' release

--- a/.opspec/release/op.yml
+++ b/.opspec/release/op.yml
@@ -64,5 +64,5 @@ run:
           - op:
               ref: $(./to-github)
               inputs:
-                github:
-                latestRelease: $(latestRelease)
+                githubAccessToken: $(github.accessToken)
+                latestRelease:

--- a/.opspec/release/to-github/op.yml
+++ b/.opspec/release/to-github/op.yml
@@ -1,19 +1,10 @@
 name: to-github
 description: releases opctl to [github](https://github.com/opctl/opctl/)
 inputs:
-  github:
-    object:
-      constraints:
-        properties:
-          accessToken:
-            minLength: 1
-            type: string
-            writeOnly: true
-          username:
-            minLength: 1
-            type: string
-        required: [accessToken, username]
-      description: configuration required to interact w/ github
+  githubAccessToken:
+    description: Access token for interacting w/ github
+    string:
+      isSecret: true
   latestRelease:
     object:
       constraints:
@@ -34,12 +25,11 @@ run:
         outputs:
           commit:
     - op:
-        ref: github.com/opspec-pkgs/github.release.create#2.0.0
+        ref: github.com/opspec-pkgs/github.release.create#3.0.0
         inputs:
           commitish: $(commit)
           description: $(latestRelease.description)
-          loginPassword: $(github.accessToken)
-          loginUsername: $(github.username)
+          accessToken: $(githubAccessToken)
           owner: opctl
           repo: opctl
           tag: v$(latestRelease.version)
@@ -68,12 +58,11 @@ run:
                   /opctl: $(../../../cli/opctl-$(target))
                   /opctl.tgz: $(opctlTgz)
             - op:
-                ref: github.com/opspec-pkgs/github.release.upload#1.0.0
+                ref: github.com/opspec-pkgs/github.release.upload#2.0.0
                 inputs:
                   asset: $(opctlTgz)
                   id: $(releaseId)
-                  loginPassword: $(github.accessToken)
-                  loginUsername: $(github.username)
+                  accessToken: $(githubAccessToken)
                   name: opctl-$(target).tgz
                   owner: opctl
                   repo: opctl


### PR DESCRIPTION
This is PR fixes an issue where if our change log release notes included JSON special characters such as double quotes, it would break the release process. This was because the `github.com/opspec-pkgs/github.release.create` op was not properly encoding them. This issue has been resolved in the latest version of that op so updating to it will resolve it. 

Unrelated:
We also updated to latest version of `github.com/opspec-pkgs/github.release.upload` in order to only need to pass `accessToken` instead of username & accessToken