### PR TITLE
Allow Failure In GPU Support Check To Just Mean GPU Passthrough Is Not Supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.61] - 2024-02-05
+
+### Fixed
+
+- Put in a short term fix so that when `pullCreds` is used on Linux against something other than `docker.io`, things don't error out any more.
+
 ## [0.1.60] - 2024-11-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ accordance with
 
 ### Fixed
 
-- Put in a short term fix so that when `pullCreds` is used on Linux against something other than `docker.io`, things don't error out any more.
+- Put in a short term fix so that when `pullCreds` is used on Linux against
+something other than `docker.io`, things don't error out any more.
 
 ## [0.1.60] - 2024-11-24
 

--- a/sdks/go/node/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/containerruntime/docker/runContainer.go
@@ -141,7 +141,8 @@ func (cr _runContainer) RunContainer(
 
 	isGpuSupported, err := isGpuSupported(ctx, cr.dockerClient, req.Image.PullCreds)
 	if nil != err {
-		return nil, err
+		// Failure to determine GPU support just really means no, GPU is not supported.
+		isGpuSupported = false
 	}
 
 	// create container


### PR DESCRIPTION
This is a short term band-aid for issue #1137. Rather than failing out entirely when GPU passthrough errors out, we simply function like GPU passthrough isn't possible.
