### PR TITLE
Leverage native privilege escalation handling for self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.64] - 2024-02-10
+
+### Added
+
+- Leverage native privilege escalation handling for self-update
+
 ## [0.1.63] - 2024-02-08
 
 ### Added

--- a/cli/selfUpdate.go
+++ b/cli/selfUpdate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/blang/semver"
+	"github.com/opctl/opctl/cli/internal/euid0"
 	"github.com/opctl/opctl/cli/internal/nodeprovider/local"
 	"github.com/rhysd/go-github-selfupdate/selfupdate"
 )
@@ -13,6 +14,10 @@ func selfUpdate(
 	ctx context.Context,
 	nodeConfig local.NodeConfig,
 ) (string, error) {
+	if err := euid0.Ensure(); err != nil {
+		return "", err
+	}
+
 	v := semver.MustParse(version)
 	latest, err := selfupdate.UpdateSelf(v, "opctl/opctl")
 	if err != nil {


### PR DESCRIPTION
This PR leverages the recently introduced native privilege escalation handling for self-update which saves people from having to "sudo self-update".