### PR TITLE
Deprecate '.opspec' directory; use '.opctl' directory instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.68] - 2024-03-17
+
+### Deprecated
+
+- `.opspec` directory; use `.opctl` instead
+
 ## [0.1.67] - 2024-03-08
 
 ### Fixed

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"github.com/opctl/opctl/cli/internal/cliparamsatisfier"
 	"github.com/opctl/opctl/cli/internal/dataresolver"
 	"github.com/opctl/opctl/cli/internal/nodeprovider/local"
+	"github.com/opctl/opctl/cli/internal/opspath"
 	"github.com/opctl/opctl/sdks/go/model"
 	"github.com/opctl/opctl/sdks/go/opspec"
 	"golang.org/x/term"
@@ -178,9 +179,18 @@ func newCli(
 	cli.Command("ls", "List operations", func(lsCmd *mow.Cmd) {
 		const dirRefArgName = "DIR_REF"
 		lsCmd.Spec = fmt.Sprintf("[%v]", dirRefArgName)
+
+		defaultDirRef, err := opspath.GetLocal()
+		if err != nil {
+			exitWith(
+				"",
+				err,
+			)
+		}
+
 		dirRef := lsCmd.String(mow.StringArg{
 			Name:   dirRefArgName,
-			Value:  "",
+			Value:  defaultDirRef,
 			Desc:   "Reference to dir ops will be listed from",
 			EnvVar: "OPCTL_LS_DIR_REF",
 		})
@@ -282,7 +292,7 @@ func newCli(
 		opCmd.Command("create", "Create an op", func(createCmd *mow.Cmd) {
 			path := createCmd.String(mow.StringOpt{
 				Name:   "path",
-				Value:  opspec.DotOpspecDirName,
+				Value:  model.DotOpspecDirName,
 				Desc:   "Path the op will be created at",
 				EnvVar: "OPCTL_CREATE_PATH",
 			})
@@ -314,7 +324,7 @@ func newCli(
 		opCmd.Command("install", "Install an op", func(installCmd *mow.Cmd) {
 			path := installCmd.String(mow.StringOpt{
 				Name:   "path",
-				Value:  opspec.DotOpspecDirName,
+				Value:  model.DotOpspecDirName,
 				Desc:   "Path the op will be installed at",
 				EnvVar: "OPCTL_INSTALL_PATH",
 			})
@@ -407,7 +417,7 @@ func newCli(
 		argFile := runCmd.String(mow.StringOpt{
 			Name:   "arg-file",
 			Desc:   "Read in a file of args in yml format",
-			Value:  filepath.Join(opspec.DotOpspecDirName, "args.yml"),
+			Value:  filepath.Join(model.DotOpspecDirName, "args.yml"),
 			EnvVar: "OPCTL_RUN_ARG_FILE",
 		})
 		noProgress := runCmd.Bool(mow.BoolOpt{

--- a/cli/internal/opspath/get.go
+++ b/cli/internal/opspath/get.go
@@ -1,0 +1,25 @@
+package opspath
+
+import (
+	"context"
+	"github.com/opctl/opctl/sdks/go/node"
+)
+
+func Get(
+	ctx context.Context,
+	startPath string,
+	node node.Node,
+) ([]string, error) {
+
+	localOpRef, err := GetLocal()
+	if err != nil {
+		return nil, err
+	}
+
+	opRefs := []string{
+		localOpRef,
+	}
+
+	return opRefs, err
+
+}

--- a/cli/internal/opspath/getLocal.go
+++ b/cli/internal/opspath/getLocal.go
@@ -1,0 +1,35 @@
+package opspath
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+func GetLocal() (
+	string,
+	error,
+) {
+	var (
+		opspecDirInfo,
+		opctlDirInfo os.FileInfo
+		err error
+	)
+	if opspecDirInfo, err = os.Stat(
+		model.DotOpspecDirName,
+	); err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if opctlDirInfo, err = os.Stat(
+		model.DotOpctlDirName,
+	); err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	if opctlDirInfo == nil && opspecDirInfo != nil {
+		// support deprecated .opspec dir until we remove support
+		return filepath.Abs(opspecDirInfo.Name())
+	}
+
+	return filepath.Abs(model.DotOpctlDirName)
+}

--- a/sdks/go/data/fs/fs_test.go
+++ b/sdks/go/data/fs/fs_test.go
@@ -77,16 +77,14 @@ var _ = Context("_fs", func() {
 						panic(err)
 					}
 
-					providedDataRef := "testdata/file1.txt"
+					providedDataRef := filepath.Join(basePath, "testdata/file1.txt")
 
 					expectedHandle := newHandle(filepath.Join(
 						basePath,
 						providedDataRef,
 					))
 
-					objectUnderTest := _fs{
-						basePaths: []string{basePath},
-					}
+					objectUnderTest := _fs{}
 
 					/* act */
 					actualHandle, actualError := objectUnderTest.TryResolve(

--- a/sdks/go/data/git/clone.go
+++ b/sdks/go/data/git/clone.go
@@ -47,7 +47,7 @@ func Clone(
 		cloneOptions,
 	); err != nil {
 		if _, ok := err.(git.NoMatchingRefSpecError); ok {
-			return fmt.Errorf("%w: version \"%s\"", model.ErrDataRefResolution{}, repoRef.Version)
+			return fmt.Errorf("%w: version \"%s\"", model.ErrDataNotFoundResolution{}, repoRef.Version)
 		}
 		if errors.Is(err, transport.ErrAuthenticationRequired) {
 			return model.ErrDataProviderAuthentication{}

--- a/sdks/go/data/resolve.go
+++ b/sdks/go/data/resolve.go
@@ -13,7 +13,7 @@ import (
 // expected errs:
 //   - ErrDataProviderAuthentication on authentication failure
 //   - ErrDataProviderAuthorization on authorization failure
-//   - ErrDataRefResolution on resolution failure
+//   - ErrDataNotFoundResolution on resolution failure
 func Resolve(
 	ctx context.Context,
 	dataRef string,
@@ -32,5 +32,5 @@ func Resolve(
 		}
 	}
 
-	return nil, fmt.Errorf("%w op \"%s\": %w", model.ErrDataUnableToResolve{}, dataRef, agg)
+	return nil, fmt.Errorf("%w \"%s\": %w", model.ErrDataUnableToResolve{}, dataRef, agg)
 }

--- a/sdks/go/data/resolve_test.go
+++ b/sdks/go/data/resolve_test.go
@@ -41,7 +41,7 @@ var _ = Context("Resolve", func() {
 				panic(err)
 			}
 			opRef := filepath.Join(wd, "testdata/testop")
-			provider0 := fs.New(filepath.Dir(opRef))
+			provider0 := fs.New()
 
 			providedProviders := []model.DataProvider{provider0}
 

--- a/sdks/go/model/errors.go
+++ b/sdks/go/model/errors.go
@@ -18,10 +18,10 @@ func (ErrDataProviderAuthorization) Error() string {
 	return "unauthorized"
 }
 
-// ErrDataRefResolution conveys no such data could be found
-type ErrDataRefResolution struct{}
+// ErrDataNotFoundResolution conveys no such data could be found
+type ErrDataNotFoundResolution struct{}
 
-func (e ErrDataRefResolution) Error() string {
+func (e ErrDataNotFoundResolution) Error() string {
 	return "not found"
 }
 

--- a/sdks/go/model/errors_test.go
+++ b/sdks/go/model/errors_test.go
@@ -38,12 +38,12 @@ var _ = Context("ErrDataProviderAuthorization", func() {
 		})
 	})
 })
-var _ = Context("ErrDataRefResolution", func() {
+var _ = Context("ErrDataNotFoundResolution", func() {
 	Context("Error", func() {
 		It("should return expected result", func() {
 			/* arrange */
 			expectedResult := "not found"
-			objectUnderTest := ErrDataRefResolution{}
+			objectUnderTest := ErrDataNotFoundResolution{}
 
 			/* act */
 			actualResult := objectUnderTest.Error()

--- a/sdks/go/model/provider.go
+++ b/sdks/go/model/provider.go
@@ -7,6 +7,8 @@ import (
 const (
 	OpFileName       = "op.yml"
 	DotOpspecDirName = ".opspec"
+	DotOpctlDirName  = ".opctl"
+	OpsDirName       = "ops"
 )
 
 // DataProvider is the interface for something that provides data
@@ -18,7 +20,7 @@ type DataProvider interface {
 	// expected errs:
 	//  - ErrDataProviderAuthentication on authentication failure
 	//  - ErrDataProviderAuthorization on authorization failure
-	//  - ErrDataRefResolution on resolution failure
+	//  - ErrDataNotFoundResolution on resolution failure
 	TryResolve(
 		ctx context.Context,
 		dataRef string,

--- a/sdks/go/node/api/client/data_ref_path_test.go
+++ b/sdks/go/node/api/client/data_ref_path_test.go
@@ -186,7 +186,7 @@ var _ = Context("GetData", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(MatchError(model.ErrDataRefResolution{}))
+				Expect(actualErr).To(MatchError(model.ErrDataNotFoundResolution{}))
 
 			})
 

--- a/sdks/go/node/api/client/data_ref_test.go
+++ b/sdks/go/node/api/client/data_ref_test.go
@@ -178,7 +178,7 @@ var _ = Context("ListDescendants", func() {
 				)
 
 				/* assert */
-				Expect(actualErr).To(Equal(model.ErrDataRefResolution{}))
+				Expect(actualErr).To(Equal(model.ErrDataNotFoundResolution{}))
 
 			})
 

--- a/sdks/go/node/api/client/getWithAuth.go
+++ b/sdks/go/node/api/client/getWithAuth.go
@@ -58,7 +58,7 @@ func (c apiClient) getWithAuth(ctx context.Context, path string, pullCreds *mode
 			}
 			return nil, fmt.Errorf("%w: %s", model.ErrDataProviderAuthorization{}, body)
 		case http.StatusNotFound:
-			return nil, model.ErrDataRefResolution{}
+			return nil, model.ErrDataNotFoundResolution{}
 		default:
 			body, err := readBody()
 			if err != nil {

--- a/sdks/go/node/api/handler/data/ref/handler.go
+++ b/sdks/go/node/api/handler/data/ref/handler.go
@@ -72,7 +72,7 @@ func (hdlr _handler) Handle(
 			} else if errors.Is(err, model.ErrDataProviderAuthorization{}) {
 				hdlr.setWWWAuthenticateHeader(dataRef, httpResp.Header())
 				status = http.StatusForbidden
-			} else if errors.Is(err, model.ErrDataRefResolution{}) || errors.Is(err, model.ErrDataUnableToResolve{}) {
+			} else if errors.Is(err, model.ErrDataNotFoundResolution{}) || errors.Is(err, model.ErrDataUnableToResolve{}) {
 				status = http.StatusNotFound
 			} else if errors.Is(err, model.ErrDataMissingVersion{}) || errors.Is(err, model.ErrDataGitInvalidRef{}) {
 				status = http.StatusBadRequest

--- a/sdks/go/node/api/handler/data/ref/handler_test.go
+++ b/sdks/go/node/api/handler/data/ref/handler_test.go
@@ -189,11 +189,11 @@ var _ = Context("Handler", func() {
 						Expect(providedHTTPResp.Header().Get("WWW-Authenticate")).To(Equal(fmt.Sprintf(`Basic realm="%s"`, dataRefSegment1)))
 					})
 				})
-				Context("err is ErrDataRefResolution", func() {
+				Context("err is ErrDataNotFoundResolution", func() {
 					It("should return expected result", func() {
 						/* arrange */
 						fakeCore := new(nodeFakes.FakeCore)
-						fakeCore.ResolveDataReturns(nil, model.ErrDataRefResolution{})
+						fakeCore.ResolveDataReturns(nil, model.ErrDataNotFoundResolution{})
 
 						objectUnderTest := _handler{
 							node: fakeCore,

--- a/sdks/go/node/core.go
+++ b/sdks/go/node/core.go
@@ -145,7 +145,7 @@ type Core interface {
 	// expected errs:
 	//  - ErrDataProviderAuthentication on authentication failure
 	//  - ErrDataProviderAuthorization on authorization failure
-	//  - ErrDataRefResolution on resolution failure
+	//  - ErrDataNotFoundResolution on resolution failure
 	ResolveData(
 		ctx context.Context,
 		dataRef string,

--- a/sdks/go/node/node.go
+++ b/sdks/go/node/node.go
@@ -53,7 +53,7 @@ type Node interface {
 	// expected errs:
 	//  - ErrDataProviderAuthentication on authentication failure
 	//  - ErrDataProviderAuthorization on authorization failure
-	//  - ErrDataRefResolution on resolution failure
+	//  - ErrDataNotFoundResolution on resolution failure
 	GetData(
 		ctx context.Context,
 		req model.GetDataReq,
@@ -67,7 +67,7 @@ type Node interface {
 	// expected errs:
 	//  - ErrDataProviderAuthentication on authentication failure
 	//  - ErrDataProviderAuthorization on authorization failure
-	//  - ErrDataRefResolution on resolution failure
+	//  - ErrDataNotFoundResolution on resolution failure
 	ListDescendants(
 		ctx context.Context,
 		req model.ListDescendantsReq,

--- a/sdks/go/node/resolveData.go
+++ b/sdks/go/node/resolveData.go
@@ -15,7 +15,7 @@ import (
 // expected errs:
 //   - ErrDataProviderAuthentication on authentication failure
 //   - ErrDataProviderAuthorization on authorization failure
-//   - ErrDataRefResolution on resolution failure
+//   - ErrDataNotFoundResolution on resolution failure
 func (cr core) ResolveData(
 	ctx context.Context,
 	dataRef string,

--- a/sdks/go/node/startOp.go
+++ b/sdks/go/node/startOp.go
@@ -20,7 +20,7 @@ func (this core) StartOp(
 	opHandle, err := data.Resolve(
 		ctx,
 		req.Op.Ref,
-		fs.New(this.dataCachePath),
+		fs.New(),
 		git.New(this.dataCachePath, req.Op.PullCreds),
 	)
 	if err != nil {

--- a/sdks/go/opspec/install_test.go
+++ b/sdks/go/opspec/install_test.go
@@ -96,7 +96,7 @@ var _ = Context("Install", func() {
 					Context("os.Chmod doesn't err", func() {
 						It("should copy content", func() {
 							/* arrange */
-							fsDataSource := fs.New("")
+							fsDataSource := fs.New()
 							ref := "testdata/testop"
 							handle, err := fsDataSource.TryResolve(providedCtx, ref)
 							if err != nil {

--- a/sdks/go/opspec/pkg.go
+++ b/sdks/go/opspec/pkg.go
@@ -1,5 +1,0 @@
-package opspec
-
-const (
-	DotOpspecDirName = ".opspec"
-)

--- a/website/docs/reference/cli/ls.md
+++ b/website/docs/reference/cli/ls.md
@@ -4,14 +4,14 @@ title: opctl ls
 ---
 
 ```sh
-opctl ls [DIR_REF=.opspec]
+opctl ls [DIR_REF=.opctl]
 ```
 
 List ops in a local or remote directory.
 
 ### Arguments
 
-#### `DIR_REF` *default: `.opspec`*
+#### `DIR_REF` *default: `.opctl`*
 Reference to dir ops will be listed from (either `relative/path`, `/absolute/path`, `host/path/repo#tag`, or `host/path/repo#tag/path`)
 
 ## Global Options
@@ -19,8 +19,8 @@ see [global options](global-options.md)
 
 ### Examples
 
-#### `.opspec` dir
-lists ops from `./.opspec`
+#### `.opctl` dir
+lists ops from `./.opctl`
 
 ```sh
 opctl ls

--- a/website/docs/reference/cli/op/create.md
+++ b/website/docs/reference/cli/op/create.md
@@ -19,7 +19,7 @@ Name of the op
 ### `-d` or `--description`
 Description of the op
 
-### `--path` *default: `.opspec`*
+### `--path` *default: `.opctl`*
 Path to create the op at
 
 ## Global Options

--- a/website/docs/reference/cli/op/install.md
+++ b/website/docs/reference/cli/op/install.md
@@ -16,7 +16,7 @@ Op reference (`host/path/repo#tag`, or `host/path/repo#tag/path`)
 
 ## Options
 
-### `--path` *default: `.opspec/OP_REF`*
+### `--path` *default: `.opctl/OP_REF`*
 Path to install the op at
 
 ### `-u` or `--username`

--- a/website/docs/reference/cli/run.md
+++ b/website/docs/reference/cli/run.md
@@ -21,7 +21,7 @@ Op reference (either `relative/path`, `/absolute/path`, `host/path/repo#tag`, or
 ### `-a`
 Explicitly pass args to op in format `-a NAME1=VALUE1 -a NAME2=VALUE2`
 
-### `--arg-file` *default: `.opspec/args.yml`*
+### `--arg-file` *default: `.opctl/args.yml`*
 Read in a file of args in yml format
 
 ### `--no-progress` *default: `false`*

--- a/website/docs/training/inputs-outputs.md
+++ b/website/docs/training/inputs-outputs.md
@@ -45,7 +45,7 @@ if you type in "you", the container will run and echo out "hello you"
 Now you may not want to be prompted for the input everytime you run the op. That's why there's several ways to accept input:
 
 1. `-a` cli flag: explicitly pass args to op. eg: `-a NAME1=VALUE1 -a NAME2=VALUE2`
-2. `--arg-file` cli flag: reads in a file of args as key=value, in yml format. eg: `--arg-file="./args.yml"`. This flag has a default value of `.opspec/args.yml` i.e. opctl will automatically check for an args file at `.opspec/args.yml`
+2. `--arg-file` cli flag: reads in a file of args as key=value, in yml format. eg: `--arg-file="./args.yml"`. This flag has a default value of `.opctl/args.yml` i.e. opctl will automatically check for an args file at `.opctl/args.yml`
 3. Environment variables: If you define an environment variable with the same name as an input on the machine you're running opctl on, its value will be supplied as the input's value
 4. `default` property: You can define a `default` property for each input, containing a value to assign if no other input method was invoked (cli args or args file)
 


### PR DESCRIPTION
This PR introduces `.opctl` as the conventional source of ops and deprecates the `.opspec` directory.