### PR TITLE
Fix accessing containers by name from opctl nodes stops working due to prior registrations not being cleaned up on container exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,25 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
-## [0.1.67] - 2024-03-08
+## [0.1.68] - 2025-03-22
+
+### Fixed
+
+- Fix accessing containers by name from opctl nodes stops working due to prior registrations not being cleaned up on container exit
+
+## [0.1.67] - 2025-03-08
 
 ### Fixed
 
 - Fix accessing Docker For Mac 4.39.0+ containers by name from opctl nodes
 
-## [0.1.66] - 2024-02-26
+## [0.1.66] - 2025-02-26
 
 ### Added
 
 - Support for environment variables for each CLI command options and arguments
 
-## [0.1.65] - 2024-02-10
+## [0.1.65] - 2025-02-10
 
 ### Added
 
@@ -26,19 +32,19 @@ accordance with
 
 - Binding opctl DNS to a non-standard port (e.g. 54)
 
-## [0.1.64] - 2024-02-10
+## [0.1.64] - 2025-02-10
 
 ### Added
 
 - Leverage native privilege escalation handling for self-update
 
-## [0.1.63] - 2024-02-08
+## [0.1.63] - 2025-02-08
 
 ### Added
 
 - Native privilege escalation handling (i.e. no more calling with sudo)
 
-## [0.1.62] - 2024-02-05
+## [0.1.62] - 2025-02-05
 
 ### Fixed
 

--- a/sdks/go/node/containerruntime/docker/runContainer.go
+++ b/sdks/go/node/containerruntime/docker/runContainer.go
@@ -54,7 +54,6 @@ func (cr _runContainer) RunContainer(
 ) (*int64, error) {
 	defer stdout.Close()
 	defer stderr.Close()
-	var containerIPAddress string
 
 	// ensure user defined network exists to allow inter container resolution via name
 	// @TODO: remove when socket outputs supported
@@ -89,13 +88,6 @@ func (cr _runContainer) RunContainer(
 				Force:         true,
 			},
 		)
-
-		if req.Name != nil {
-			dns.UnregisterName(
-				*req.Name,
-				containerIPAddress,
-			)
-		}
 	}()
 
 	var imageErr error
@@ -213,6 +205,11 @@ func (cr _runContainer) RunContainer(
 		}
 
 		if endpointSettings, ok := containerJSON.NetworkSettings.Networks[networkName]; ok {
+			defer dns.UnregisterName(
+				*req.Name,
+				endpointSettings.IPAddress,
+			)
+
 			err = dns.RegisterName(
 				ctx,
 				*req.Name,


### PR DESCRIPTION
This PR fixes a bug where container name registrations were not being cleaned up on container exit. This led to name registrations becoming invalid as the previously assigned IPs were assigned to new containers with different names.