### PR TITLE
Support specifying image.platform.arch in container calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.69] - 2025-04-02
+
+### Added
+
+- Support for specifying image.platform.arch in container calls
+
 ## [0.1.68] - 2025-03-22
 
 ### Fixed

--- a/opspec/opfile/jsonschema.json
+++ b/opspec/opfile/jsonschema.json
@@ -926,12 +926,19 @@
                   "description": "Image reference to resolve from network.",
                   "$ref": "#/definitions/expression"
                 },
+                "platform": {
+                  "type": "object",
+                  "properties": {
+                    "arch": {
+                      "description": "Architecture of image. MUST be a valid [v1.0.1 OCI (Open Container Initiative) `image-index`](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md) platform architecture"
+                    }
+                  },
+                  "required": [
+                    "arch"
+                  ]
+                },
                 "pullCreds": {
                   "$ref": "#/definitions/pullCreds"
-                },
-                "src": {
-                  "description": "Source of image. MUST be a valid [v1.0.1 OCI (Open Container Initiative) `image-layout`](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-layout.md) directory.",
-                  "type": "string"
                 }
               },
               "required": [

--- a/sdks/go/model/call.go
+++ b/sdks/go/model/call.go
@@ -52,9 +52,10 @@ type ContainerCall struct {
 
 // ContainerCallImage is the image used when calling a container
 type ContainerCallImage struct {
-	Src       *Value  `json:"src,omitempty"`
-	Ref       *string `json:"ref"`
-	PullCreds *Creds  `json:"pullCreds,omitempty"`
+	Platform  *OCIImagePlatform `json:"platform,omitempty"`
+	PullCreds *Creds            `json:"pullCreds,omitempty"`
+	Ref       *string           `json:"ref"`
+	Src       *Value            `json:"src,omitempty"`
 }
 
 // Creds contains authentication credentials
@@ -68,6 +69,10 @@ type LoopVars struct {
 	Index *string `json:"index,omitempty"`
 	Key   *string `json:"key,omitempty"`
 	Value *string `json:"value,omitempty"`
+}
+
+type OCIImagePlatform struct {
+	Arch *string `json:"arch,omitempty"`
 }
 
 // OpCall is a call of an op

--- a/sdks/go/model/opSpec.go
+++ b/sdks/go/model/opSpec.go
@@ -44,8 +44,9 @@ type ContainerCallSpec struct {
 
 // ContainerCallImageSpec is a spec for the image when calling a container
 type ContainerCallImageSpec struct {
-	Ref       string     `json:"ref"`
-	PullCreds *CredsSpec `json:"pullCreds,omitempty"`
+	Platform  *OCIImagePlatformSpec `json:"platform,omitempty"`
+	PullCreds *CredsSpec            `json:"pullCreds,omitempty"`
+	Ref       string                `json:"ref"`
 }
 
 // LoopVarsSpec is a spec for a loops vars
@@ -65,6 +66,10 @@ type OpCallSpec struct {
 	Inputs map[string]interface{} `json:"inputs,omitempty"`
 	// binds scope to outputs of referenced op
 	Outputs map[string]string `json:"outputs,omitempty"`
+}
+
+type OCIImagePlatformSpec struct {
+	Arch string `json:"arch,omitempty"`
 }
 
 // ParallelLoopCallSpec is a spec for calling a parallel loop

--- a/sdks/go/node/containerruntime/docker/pullImage.go
+++ b/sdks/go/node/containerruntime/docker/pullImage.go
@@ -45,9 +45,21 @@ func pullImage(
 	imagePullCreds := containerCall.Image.PullCreds
 	containerID := containerCall.ContainerID
 
-	imagePullOptions := image.PullOptions{
-		Platform: "linux",
+	platformParts := []string{
+		"linux",
 	}
+
+	if containerCall.Image.Platform != nil && containerCall.Image.Platform.Arch != nil {
+		platformParts = append(platformParts, *containerCall.Image.Platform.Arch)
+	}
+
+	imagePullOptions := image.PullOptions{
+		Platform: strings.Join(
+			platformParts,
+			"/",
+		),
+	}
+
 	if imagePullCreds != nil &&
 		imagePullCreds.Username != "" &&
 		imagePullCreds.Password != "" {

--- a/sdks/go/opspec/interpreter/call/container/image/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/image/interpret.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec/interpreter/call/container/image/platform"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/dir"
 	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
 )
@@ -43,6 +44,19 @@ func Interpret(
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if containerCallImageSpec.Platform != nil {
+		platform, err := platform.Interpret(
+			scope,
+			containerCallImageSpec.Platform,
+			scratchDir,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		containerCallImage.Platform = platform
 	}
 
 	parsedRef, err := reference.ParseAnyReference(strings.ToLower(*ref.String))

--- a/sdks/go/opspec/interpreter/call/container/image/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/image/interpret_test.go
@@ -29,6 +29,8 @@ var _ = Context("Interpret", func() {
 		It("should return expected result", func() {
 
 			/* arrange */
+			archVariable := "archVariable"
+			archValue := "archValue"
 			refVariable := "refVariable"
 			refValue := "refValue"
 			usernameVariable := "usernameVariable"
@@ -37,6 +39,9 @@ var _ = Context("Interpret", func() {
 			passwordValue := "passwordValue"
 
 			providedScope := map[string]*model.Value{
+				archVariable: {
+					String: &archValue,
+				},
 				usernameVariable: {
 					String: &usernameValue,
 				},
@@ -50,6 +55,9 @@ var _ = Context("Interpret", func() {
 
 			providedContainerCallImageSpec := &model.ContainerCallImageSpec{
 				Ref: fmt.Sprintf("$(%s)", refVariable),
+				Platform: &model.OCIImagePlatformSpec{
+					Arch: fmt.Sprintf("$(%s)", archVariable),
+				},
 				PullCreds: &model.CredsSpec{
 					Username: fmt.Sprintf("$(%s)", usernameVariable),
 					Password: fmt.Sprintf("$(%s)", passwordVariable),
@@ -65,6 +73,9 @@ var _ = Context("Interpret", func() {
 
 			expectedImage := &model.ContainerCallImage{
 				Ref: &expectedImageRef,
+				Platform: &model.OCIImagePlatform{
+					Arch: &archValue,
+				},
 				PullCreds: &model.Creds{
 					Username: usernameValue,
 					Password: passwordValue,

--- a/sdks/go/opspec/interpreter/call/container/image/platform/interpret.go
+++ b/sdks/go/opspec/interpreter/call/container/image/platform/interpret.go
@@ -1,0 +1,26 @@
+package platform
+
+import (
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/opspec/interpreter/str"
+)
+
+// Interpret OCI Image Platform
+func Interpret(
+	scope map[string]*model.Value,
+	imagePlatformSpec *model.OCIImagePlatformSpec,
+	scratchDir string,
+) (*model.OCIImagePlatform, error) {
+	ociImagePlatform := &model.OCIImagePlatform{}
+	arch, err := str.Interpret(
+		scope,
+		imagePlatformSpec.Arch,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	ociImagePlatform.Arch = arch.String
+
+	return ociImagePlatform, nil
+}

--- a/sdks/go/opspec/interpreter/call/container/image/platform/interpret_test.go
+++ b/sdks/go/opspec/interpreter/call/container/image/platform/interpret_test.go
@@ -1,0 +1,41 @@
+package platform
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+var _ = Context("Interpret", func() {
+	It("should return expected result", func() {
+		/* arrange */
+		archVariable := "archVariable"
+		archValue := "archValue"
+
+		providedScope := map[string]*model.Value{
+			archVariable: {
+				String: &archValue,
+			},
+		}
+
+		providedImagePlatformSpec := &model.OCIImagePlatformSpec{
+			Arch: fmt.Sprintf("$(%s)", archVariable),
+		}
+
+		expectedImagePlatform := &model.OCIImagePlatform{
+			Arch: &archValue,
+		}
+
+		/* act */
+		actualContainerCallImage, actualErr := Interpret(
+			providedScope,
+			providedImagePlatformSpec,
+			"dummyScratchDir",
+		)
+
+		/* assert */
+		Expect(actualErr).To(BeNil())
+		Expect(actualContainerCallImage).To(Equal(expectedImagePlatform))
+	})
+})

--- a/sdks/go/opspec/interpreter/call/container/image/platform/pkg.go
+++ b/sdks/go/opspec/interpreter/call/container/image/platform/pkg.go
@@ -1,0 +1,2 @@
+// Package platform exposes functionality for interpreting platform of container call images.
+package platform

--- a/sdks/go/opspec/interpreter/call/container/image/platform/suite_test.go
+++ b/sdks/go/opspec/interpreter/call/container/image/platform/suite_test.go
@@ -1,0 +1,12 @@
+package platform
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "opspec/interpreter/call/container/image/platform")
+}

--- a/website/docs/reference/opspec/op-directory/op/call/container/image.md
+++ b/website/docs/reference/opspec/op-directory/op/call/container/image.md
@@ -8,6 +8,7 @@ An object which defines the image of a container call.
 - must have
   - [ref](#ref)
 - may have
+  - [platform](#platform)
   - [pullCreds](#pullcreds)
 
 ### ref
@@ -22,6 +23,9 @@ Must be one of:
 
 ### Example ref (variable)
 `ref: $(myOCIImageLayoutDir)`
+
+### platform
+An [oci-image-platform [object]](../oci-image-platform.md) constraining the image which will be pulled from the source.
 
 ### pullCreds
 A [pull-creds [object]](../pull-creds.md) defining creds used to pull the image from a private source.

--- a/website/docs/reference/opspec/op-directory/op/call/oci-image-platform.md
+++ b/website/docs/reference/opspec/op-directory/op/call/oci-image-platform.md
@@ -1,0 +1,18 @@
+---
+title: OCI Image Platform [object]
+---
+
+An object defining the platform for an OCI image.
+
+## Properties
+- must have
+  - [arch](#arch)
+
+### arch
+A [string initializer](../../../types/string.md#initialization) specifying a [v1.0.1 OCI (Open Container Initiative) `image-index`](https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md) platform architecture.
+
+### Example arch
+`arch: amd64`
+
+### Example arch (variable)
+`arch: $(myArch)`


### PR DESCRIPTION
This PR adds the ability to specify image platform architecture (e.g. `amd64`) in order to ensure containers requiring images built for a particular architecture don't break when run on nodes with different architecture.

example op using it:
```yaml
name: examplePlatformUsage
run:
  container:
    image:
      ref: amd64/python:3.12
      platform:
        arch: amd64
```

Unrelated:
This PR also removes container.image.src attribute in the opspec JSON schema; it is [not used/supported in code](https://github.com/opctl/opctl/blob/155cc1f46837790c9da3be8c7b1f346ca07d503a/sdks/go/model/opSpec.go#L46)

closes #1156