### PR TITLE
Update embedded container runtime to run as caller UID & GID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.74] - 2025-09-26
+
+### Fixed
+
+- ls and ui command examples now reference valid ops
+- embedded container runtime now uses caller UID & GID (instead of hardcoded UID & GID)
+
 ## [0.1.73] - 2025-09-16
 
 ### Added

--- a/sdks/go/internal/unsudo/newCmd.go
+++ b/sdks/go/internal/unsudo/newCmd.go
@@ -1,0 +1,21 @@
+package unsudo
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+// NewCmd that will run as the user & group who ran sudo
+func NewCmd(ctx context.Context, name string, arg ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, name, arg...)
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(getSudoUID()),
+			Gid: uint32(getSudoGID()),
+		},
+	}
+
+	return cmd
+}

--- a/sdks/go/node/containerruntime/embedded/ensureLimaBinaries.go
+++ b/sdks/go/node/containerruntime/embedded/ensureLimaBinaries.go
@@ -54,5 +54,6 @@ func writeBinary(path string, data []byte) error {
 	if err := unsudo.CreateFile(path, data); err != nil {
 		return fmt.Errorf("failed to create binary file: %w", err)
 	}
+
 	return nil
 }


### PR DESCRIPTION
This PR includes a small update to remove a hardcoded UID and GID from the embedded container runtime (which may not exist on a given system), in favor of using the callers UID & GID, (which is guaranteed to exist on a given system).