### PR TITLE
Detect re-tagged git ops and re-fetch when the tag has moved

### DIFF
--- a/.opspec/changelog/find-in-diff/op.yml
+++ b/.opspec/changelog/find-in-diff/op.yml
@@ -3,7 +3,7 @@ name: check-for-changelog
 run:
   container:
     image:
-      ref: bitnami/git:2.45.0
+      ref: bitnami/git:latest
     cmd:
       - /bin/sh
       - -c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.75] - 2026-03-19
+
+### Fixed
+
+- Git ops with re-pointed tags (e.g. floating `v1` tags) are now re-fetched when the remote tag points to a new commit
+
 ## [0.1.74] - 2025-09-26
 
 ### Fixed

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -64,7 +63,7 @@ func (np nodeProvider) CreateNodeIfNotExists(
 	cmd.Stdout = os.Stdout
 
 	var stderr bytes.Buffer
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
+	cmd.Stderr = &stderr
 
 	// don't inherit env; some things like jenkins track and kill processes via injecting env vars
 	cmd.Env = []string{

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -63,7 +64,7 @@ func (np nodeProvider) CreateNodeIfNotExists(
 	cmd.Stdout = os.Stdout
 
 	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 
 	// don't inherit env; some things like jenkins track and kill processes via injecting env vars
 	cmd.Env = []string{

--- a/sdks/go/data/git/git.go
+++ b/sdks/go/data/git/git.go
@@ -5,10 +5,12 @@ package git
 import (
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/opctl/opctl/sdks/go/model"
 	"golang.org/x/sync/singleflight"
 )
@@ -57,9 +59,11 @@ func (gp _git) TryResolve(
 			// without cloning (equivalent to git ls-remote)
 			remoteHash, hashErr := resolveRemoteHash(ctx, repoRef, gp.pullCreds)
 			if hashErr != nil {
-				// can't reach remote — fall back to cache if available, else fail
-				if _, err := os.Stat(completeMarkerPath); err == nil {
-					return nil, nil
+				if errors.Is(hashErr, transport.ErrAuthenticationRequired) {
+					return nil, model.ErrDataProviderAuthentication{}
+				}
+				if errors.Is(hashErr, transport.ErrAuthorizationFailed) {
+					return nil, model.ErrDataProviderAuthorization{}
 				}
 				return nil, hashErr
 			}
@@ -77,11 +81,7 @@ func (gp _git) TryResolve(
 			os.RemoveAll(tmpPath)
 
 			if cloneErr := Clone(ctx, tmpPath, repoRef, gp.pullCreds); cloneErr != nil {
-				// clone failed — fall back to cache if available
 				os.RemoveAll(tmpPath)
-				if _, err := os.Stat(completeMarkerPath); err == nil {
-					return nil, nil
-				}
 				return nil, cloneErr
 			}
 

--- a/sdks/go/data/git/git.go
+++ b/sdks/go/data/git/git.go
@@ -51,30 +51,48 @@ func (gp _git) TryResolve(
 	if _, err, _ := resolveSingleFlightGroup.Do(
 		repoPath,
 		func() (interface{}, error) {
-			// we'll mark complete clones in case we get interrupted
 			completeMarkerPath := filepath.Join(gp.basePath, fmt.Sprintf(".%x", sha1.Sum([]byte(repoPath))))
 
-			_, err := os.Stat(completeMarkerPath)
-			if err == nil {
-				// complete clone found
-				return nil, nil
-			} else if os.IsNotExist(err) {
-				// incomplete clone; blow it away
-				if err := os.RemoveAll(repoPath); err != nil {
-					return nil, err
+			// lightweight check: resolve the tag to a commit SHA on the remote
+			// without cloning (equivalent to git ls-remote)
+			remoteHash, hashErr := resolveRemoteHash(ctx, repoRef, gp.pullCreds)
+			if hashErr != nil {
+				// can't reach remote — fall back to cache if available, else fail
+				if _, err := os.Stat(completeMarkerPath); err == nil {
+					return nil, nil
+				}
+				return nil, hashErr
+			}
+
+			// if the cached hash matches the remote, nothing has changed
+			if cachedHash, err := os.ReadFile(completeMarkerPath); err == nil {
+				if string(cachedHash) == remoteHash {
+					return nil, nil
 				}
 			}
 
-			// attempt clone
-			if err := Clone(ctx, repoPath, repoRef, gp.pullCreds); err != nil {
-				return nil, err
+			// tag has moved (or no cache) — clone into a temp path so the
+			// existing cache is never disturbed until the new clone succeeds
+			tmpPath := repoPath + ".tmp"
+			os.RemoveAll(tmpPath)
+
+			if cloneErr := Clone(ctx, tmpPath, repoRef, gp.pullCreds); cloneErr != nil {
+				// clone failed — fall back to cache if available
+				os.RemoveAll(tmpPath)
+				if _, err := os.Stat(completeMarkerPath); err == nil {
+					return nil, nil
+				}
+				return nil, cloneErr
 			}
 
-			// mark complete
-			if err := os.WriteFile(completeMarkerPath, nil, 0755); err != nil {
+			// atomically replace the cached copy and record the new hash
+			os.RemoveAll(repoPath)
+			if err := os.Rename(tmpPath, repoPath); err != nil {
 				return nil, err
 			}
-
+			if err := os.WriteFile(completeMarkerPath, []byte(remoteHash), 0755); err != nil {
+				return nil, err
+			}
 			return nil, nil
 		},
 	); err != nil {

--- a/sdks/go/data/git/git_test.go
+++ b/sdks/go/data/git/git_test.go
@@ -2,6 +2,8 @@ package git
 
 import (
 	"context"
+	"crypto/sha1"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -76,6 +78,73 @@ var _ = Context("_git", func() {
 						Expect(actualError).To(BeNil())
 					})
 				})
+			})
+		})
+		Context("remote hash matches cached marker", func() {
+			It("should return handle without re-cloning", func() {
+				/* arrange */
+				providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
+				basePath, err := os.MkdirTemp("", "")
+				if err != nil {
+					panic(err)
+				}
+				objectUnderTest := New(basePath, nil)
+
+				// first call — populates cache and writes the hash marker
+				_, err = objectUnderTest.TryResolve(context.Background(), providedRef)
+				Expect(err).To(BeNil())
+
+				// record marker mtime before second call
+				repoPath := filepath.Join(basePath, providedRef)
+				markerPath := filepath.Join(basePath, fmt.Sprintf(".%x", sha1.Sum([]byte(repoPath))))
+				markerInfoBefore, err := os.Stat(markerPath)
+				Expect(err).To(BeNil())
+
+				/* act — second call with same hash should hit cache */
+				actualHandle, actualErr := objectUnderTest.TryResolve(context.Background(), providedRef)
+
+				/* assert */
+				Expect(actualErr).To(BeNil())
+				Expect(actualHandle).NotTo(BeNil())
+
+				// marker must not have been rewritten (mtime unchanged = no re-clone)
+				markerInfoAfter, err := os.Stat(markerPath)
+				Expect(err).To(BeNil())
+				Expect(markerInfoAfter.ModTime()).To(Equal(markerInfoBefore.ModTime()))
+			})
+		})
+		Context("cached marker contains stale hash (tag re-pointed)", func() {
+			It("should re-clone and update the marker", func() {
+				/* arrange */
+				providedRef := "github.com/opspec-pkgs/_.op.create#3.3.1"
+				basePath, err := os.MkdirTemp("", "")
+				if err != nil {
+					panic(err)
+				}
+				objectUnderTest := New(basePath, nil)
+
+				// first call — populates cache
+				_, err = objectUnderTest.TryResolve(context.Background(), providedRef)
+				Expect(err).To(BeNil())
+
+				// overwrite the marker with a fake hash to simulate a re-tagged commit
+				repoPath := filepath.Join(basePath, providedRef)
+				markerPath := filepath.Join(basePath, fmt.Sprintf(".%x", sha1.Sum([]byte(repoPath))))
+				err = os.WriteFile(markerPath, []byte("0000000000000000000000000000000000000000"), 0755)
+				Expect(err).To(BeNil())
+
+				/* act — should detect hash mismatch and re-clone */
+				actualHandle, actualErr := objectUnderTest.TryResolve(context.Background(), providedRef)
+
+				/* assert */
+				Expect(actualErr).To(BeNil())
+				Expect(actualHandle).NotTo(BeNil())
+
+				// marker must now contain the real hash, not our fake one
+				updatedHash, err := os.ReadFile(markerPath)
+				Expect(err).To(BeNil())
+				Expect(string(updatedHash)).NotTo(Equal("0000000000000000000000000000000000000000"))
+				Expect(len(string(updatedHash))).To(Equal(40)) // SHA-1 hex length
 			})
 		})
 		Context("called in parallel w/ same pkg ref", func() {

--- a/sdks/go/data/git/remote.go
+++ b/sdks/go/data/git/remote.go
@@ -1,0 +1,58 @@
+package git
+
+import (
+	"context"
+	"fmt"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/storage/memory"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+// resolveRemoteHash returns the commit SHA that the given tag points to on the
+// remote.  For annotated tags it returns the peeled (dereferenced) commit SHA;
+// for lightweight tags it returns the tag SHA directly.  The operation is
+// equivalent to `git ls-remote` — no clone is performed.
+func resolveRemoteHash(ctx context.Context, repoRef *ref, creds *model.Creds) (string, error) {
+	remote := gogit.NewRemote(memory.NewStorage(), &config.RemoteConfig{
+		URLs: []string{fmt.Sprintf("https://%v", repoRef.Name)},
+	})
+
+	listOpts := &gogit.ListOptions{
+		PeelingOption: gogit.AppendPeeled,
+	}
+	if creds != nil {
+		listOpts.Auth = &http.BasicAuth{
+			Username: creds.Username,
+			Password: creds.Password,
+		}
+	}
+
+	refs, err := remote.ListContext(ctx, listOpts)
+	if err != nil {
+		return "", err
+	}
+
+	tagRef := plumbing.NewTagReferenceName(repoRef.Version)
+	peeledRef := plumbing.ReferenceName(fmt.Sprintf("refs/tags/%s^{}", repoRef.Version))
+
+	var tagHash string
+	for _, r := range refs {
+		switch r.Name() {
+		case peeledRef:
+			// annotated tag dereferenced to commit — most precise, prefer this
+			return r.Hash().String(), nil
+		case tagRef:
+			tagHash = r.Hash().String()
+		}
+	}
+
+	if tagHash != "" {
+		return tagHash, nil
+	}
+
+	return "", fmt.Errorf("tag %q not found on remote %s", repoRef.Version, repoRef.Name)
+}


### PR DESCRIPTION
## Background

opctl caches git ops locally and uses the presence of a marker file to skip re-cloning on subsequent runs. This works fine for immutable tags, but git tags are mutable — they can be force-pushed to point at a different commit at any time.

A pattern common in the GitHub Actions ecosystem (and [recommended by GitHub](https://docs.github.com/en/actions/how-tos/create-and-publish-actions/using-immutable-releases-and-tags-to-manage-your-actions-releases)) is to maintain a "floating" major version tag (e.g. `v1`) that always points to the latest stable release within that major. This lets consumers pin to `myop#v1` and receive updates automatically without changing their op reference.

opctl's current caching strategy makes this impossible — once `v1` is cached, it is never re-fetched regardless of where the tag now points.

## What this changes

Before cloning (or deciding to skip a clone), opctl now runs the equivalent of `git ls-remote` against the remote to resolve what commit the tag currently points to. It compares that hash against what was cached locally:

- If the hashes match, the cache is used as before.
- If the hashes differ (tag was re-pointed), the op is re-cloned into a temporary path and atomically replaces the cached copy only after the clone succeeds, so a failed re-clone never corrupts the existing cache.