### PR TITLE
use scutil for dns registration instead of resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ coverage/
 ### build
 /cli/opctl-*
 /opctl-*
+
+## MacOS
+.DS_Store

--- a/sdks/go/node/dns/internal/resolvercfg/apply_darwin.go
+++ b/sdks/go/node/dns/internal/resolvercfg/apply_darwin.go
@@ -1,15 +1,13 @@
 package resolvercfg
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"os"
-	"path"
+	"os/exec"
+	"strings"
 )
 
-var resolverPrefix = "opctl_"
-var resolverDir = "/etc/resolver"
+var scutilKeyPrefix = "State:/Network/Service/opctl_"
 
 // Apply to the current system
 func Apply(
@@ -18,54 +16,31 @@ func Apply(
 	nsIPAddress,
 	nsPort string,
 ) error {
-	var buf bytes.Buffer
-	buf.WriteString(
-		"# do not edit; managed by opctl\n",
-	)
+	key := scutilKeyPrefix + domain + "/DNS"
 
-	buf.WriteString(
-		fmt.Sprintf(
-			"domain %s\n",
-			domain,
-		),
-	)
-
-	buf.WriteString(
-		fmt.Sprintf(
-			"nameserver %s\n",
-			nsIPAddress,
-		),
-	)
-
+	var sb strings.Builder
+	sb.WriteString("d.init\n")
+	sb.WriteString(fmt.Sprintf("d.add ServerAddresses * %s\n", nsIPAddress))
 	if nsPort != "53" {
-		buf.WriteString(
-			fmt.Sprintf(
-				"port %s\n",
-				nsPort,
-			),
-		)
+		sb.WriteString(fmt.Sprintf("d.add ServerPort # %s\n", nsPort))
 	}
+	sb.WriteString(fmt.Sprintf("d.add SupplementalMatchDomains * %s\n", domain))
+	sb.WriteString(fmt.Sprintf("set %s\n", key))
 
-	buf.WriteString(
-		"nameserver 8.8.8.8\n",
+	cmd := exec.CommandContext(
+		ctx,
+		"scutil",
 	)
+	cmd.Stdin = strings.NewReader(sb.String())
 
-	if err := os.MkdirAll(
-		resolverDir,
-		0755,
-	); err != nil {
-		return err
+	outputBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to apply resolver config via scutil: %w, %s", err, string(outputBytes))
 	}
 
-	if err := os.WriteFile(
-		path.Join(
-			resolverDir,
-			resolverPrefix+domain,
-		),
-		buf.Bytes(),
-		0644,
-	); err != nil {
-		return err
+	// scutil exits 0 even on permission errors, so check output
+	if strings.Contains(string(outputBytes), "Permission denied") {
+		return fmt.Errorf("failed to apply resolver config via scutil: permission denied (run as root)")
 	}
 
 	return clearCaches(ctx)

--- a/sdks/go/node/dns/internal/resolvercfg/apply_darwin.go
+++ b/sdks/go/node/dns/internal/resolvercfg/apply_darwin.go
@@ -9,6 +9,15 @@ import (
 
 var scutilKeyPrefix = "State:/Network/Service/opctl_"
 
+// validateScutilInput ensures a value is safe to interpolate into scutil stdin commands.
+// scutil reads commands line-by-line, so newlines would allow command injection.
+func validateScutilInput(name, value string) error {
+	if strings.ContainsAny(value, "\n\r") {
+		return fmt.Errorf("invalid %s %q: must not contain newlines", name, value)
+	}
+	return nil
+}
+
 // Apply to the current system
 func Apply(
 	ctx context.Context,
@@ -16,6 +25,16 @@ func Apply(
 	nsIPAddress,
 	nsPort string,
 ) error {
+	for name, value := range map[string]string{
+		"domain":    domain,
+		"address":   nsIPAddress,
+		"port":      nsPort,
+	} {
+		if err := validateScutilInput(name, value); err != nil {
+			return err
+		}
+	}
+
 	key := scutilKeyPrefix + domain + "/DNS"
 
 	var sb strings.Builder

--- a/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
+++ b/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
@@ -1,9 +1,12 @@
 package resolvercfg
 
 import (
+	"bufio"
 	"context"
+	"fmt"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -12,33 +15,77 @@ import (
 func Delete(
 	ctx context.Context,
 ) error {
-	if err := filepath.WalkDir(
-		resolverDir,
-		func(path string, d fs.DirEntry, err error) error {
-			if err != nil && !os.IsNotExist(err) {
-				if os.IsNotExist(err) {
-					return nil
-				}
-
-				return err
-			}
-
-			if d == nil {
-				return nil
-			}
-
-			if strings.HasPrefix(
-				d.Name(),
-				resolverPrefix,
-			) {
-				return os.Remove(path)
-			}
-
-			return nil
-		},
-	); err != nil {
+	if err := deleteScutilEntries(ctx); err != nil {
 		return err
 	}
 
+	// Clean up legacy /etc/resolver/opctl_* files from older versions
+	deleteLegacyResolverFiles()
+
 	return clearCaches(ctx)
+}
+
+func deleteScutilEntries(ctx context.Context) error {
+	// List all opctl resolver keys in the Dynamic Store
+	listCmd := exec.CommandContext(ctx, "scutil")
+	listCmd.Stdin = strings.NewReader(
+		fmt.Sprintf("list %s.*/DNS\n", scutilKeyPrefix),
+	)
+
+	output, err := listCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to list resolver configs via scutil: %w, %s", err, string(output))
+	}
+
+	// Parse output for keys to remove
+	var removeCmds strings.Builder
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// scutil list output lines look like: "  subKey [0] = State:/Network/Service/opctl_foo/DNS"
+		if idx := strings.Index(line, "= "); idx >= 0 {
+			key := strings.TrimSpace(line[idx+2:])
+			if strings.HasPrefix(key, scutilKeyPrefix) {
+				removeCmds.WriteString(fmt.Sprintf("remove %s\n", key))
+			}
+		}
+	}
+
+	if removeCmds.Len() == 0 {
+		return nil
+	}
+
+	removeCmd := exec.CommandContext(ctx, "scutil")
+	removeCmd.Stdin = strings.NewReader(removeCmds.String())
+
+	outputBytes, err := removeCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to remove resolver configs via scutil: %w, %s", err, string(outputBytes))
+	}
+
+	// scutil exits 0 even on permission errors, so check output
+	if strings.Contains(string(outputBytes), "Permission denied") {
+		return fmt.Errorf("failed to remove resolver configs via scutil: permission denied (run as root)")
+	}
+
+	return nil
+}
+
+// deleteLegacyResolverFiles removes /etc/resolver/opctl_* files left by older versions.
+func deleteLegacyResolverFiles() {
+	legacyDir := "/etc/resolver"
+	legacyPrefix := "opctl_"
+
+	_ = filepath.WalkDir(
+		legacyDir,
+		func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d == nil {
+				return nil
+			}
+			if strings.HasPrefix(d.Name(), legacyPrefix) {
+				_ = os.Remove(path)
+			}
+			return nil
+		},
+	)
 }

--- a/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
+++ b/sdks/go/node/dns/internal/resolvercfg/delete_darwin.go
@@ -29,7 +29,7 @@ func deleteScutilEntries(ctx context.Context) error {
 	// List all opctl resolver keys in the Dynamic Store
 	listCmd := exec.CommandContext(ctx, "scutil")
 	listCmd.Stdin = strings.NewReader(
-		fmt.Sprintf("list %s.*/DNS\n", scutilKeyPrefix),
+		fmt.Sprintf("list %s[^/]+/DNS\n", scutilKeyPrefix),
 	)
 
 	output, err := listCmd.CombinedOutput()


### PR DESCRIPTION
## Problem
On macOS, opctl runs a local DNS server (default 127.0.0.1:53) so that containers with a name field (e.g., stateful-partner-bridge.opctl) are resolvable from the host. Previously, opctl configured this by writing per-domain files to /etc/resolver/ -- macOS's built-in mechanism for routing DNS queries for specific domains to specific nameservers.
This works fine in isolation, but breaks when a VPN (like Pritunl/OpenVPN) is active. The VPN registers its DNS configuration in macOS's SCDynamicStore with SupplementalMatchDomains set to an empty string, which acts as a catch-all that matches all domains. Because /etc/resolver/ files and SCDynamicStore entries don't participate in the same priority evaluation, the VPN's catch-all intercepts queries for .opctl domains before they reach opctl's DNS server. The VPN's corporate DNS servers don't know about .opctl and return NXDOMAIN.

## Fix
Replace the /etc/resolver/ file approach with SCDynamicStore registration via scutil. This puts opctl's domain-specific resolvers into the same priority system the VPN uses. macOS's resolver matching rule is "longest domain match wins" -- so opctl (specific match) beats "" (empty catch-all), and queries for .opctl domains are correctly routed to opctl's DNS server regardless of VPN state.
The cleanup path (node kill, node delete) was updated to remove the new scutil entries and also clean up any legacy /etc/resolver/opctl_* files left by older versions. Both apply and delete also detect scutil's silent permission errors (it exits 0 but prints "Permission denied" to stdout).