### PR TITLE
Propagate proxy env vars from the opctl node into op containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [0.1.76] - 2026-06-18
+
+### Added
+
+- Proxy env vars (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY`, and their lowercase forms) from the
+opctl node's environment are now propagated into op containers, unless the op already set them
+
 ## [0.1.75] - 2026-03-19
 
 ### Fixed

--- a/cli/internal/nodeprovider/local/createNodeIfNotExists.go
+++ b/cli/internal/nodeprovider/local/createNodeIfNotExists.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/opctl/opctl/cli/internal/euid0"
 	"github.com/opctl/opctl/sdks/go/node"
+	"github.com/opctl/opctl/sdks/go/node/containerruntime"
 )
 
 func (np nodeProvider) CreateNodeIfNotExists(
@@ -65,14 +66,7 @@ func (np nodeProvider) CreateNodeIfNotExists(
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
-	// don't inherit env; some things like jenkins track and kill processes via injecting env vars
-	cmd.Env = []string{
-		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
-		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
-		// set by sudo; passthru so we maintain provenance for use by "unsudo"
-		fmt.Sprintf("SUDO_GID=%s", os.Getenv("SUDO_GID")),
-		fmt.Sprintf("SUDO_UID=%s", os.Getenv("SUDO_UID")),
-	}
+	cmd.Env = daemonEnv()
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// own process group
@@ -117,4 +111,29 @@ func (np nodeProvider) CreateNodeIfNotExists(
 	}
 
 	return apiClientNode, nil
+}
+
+// daemonEnv builds the environment for the daemonized node process.
+//
+// We deliberately don't inherit the full env; some things (e.g. jenkins) track
+// and kill processes via injected env vars. We pass through only what the node
+// needs: HOME & PATH, the SUDO_* provenance used by "unsudo", and the proxy
+// vars so the node (and the op containers it runs, see
+// containerruntime.ProxyEnvVars) can reach the network on hosts whose only
+// egress route is an HTTP/HTTPS forward proxy (e.g. CI runners).
+func daemonEnv() []string {
+	env := []string{
+		fmt.Sprintf("HOME=%s", os.Getenv("HOME")),
+		fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
+		// set by sudo; passthru so we maintain provenance for use by "unsudo"
+		fmt.Sprintf("SUDO_GID=%s", os.Getenv("SUDO_GID")),
+		fmt.Sprintf("SUDO_UID=%s", os.Getenv("SUDO_UID")),
+	}
+
+	// passing nil yields every proxy var present in this process's environment
+	for name, value := range containerruntime.ProxyEnvVars(nil) {
+		env = append(env, fmt.Sprintf("%s=%s", name, value))
+	}
+
+	return env
 }

--- a/cli/internal/nodeprovider/local/daemonEnv_test.go
+++ b/cli/internal/nodeprovider/local/daemonEnv_test.go
@@ -1,0 +1,53 @@
+//go:build darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
+
+package local
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDaemonEnv verifies the daemonized node inherits proxy vars (so op
+// containers can reach the network behind a forward proxy) but does not
+// inherit arbitrary env. Save/restore env so the host can't perturb results.
+func TestDaemonEnv(t *testing.T) {
+	for _, name := range []string{"HTTP_PROXY", "https_proxy", "NO_PROXY", "OPCTL_UNRELATED"} {
+		if orig, ok := os.LookupEnv(name); ok {
+			defer os.Setenv(name, orig)
+		} else {
+			defer os.Unsetenv(name)
+		}
+	}
+
+	os.Setenv("HTTP_PROXY", "http://proxy.example:3128")
+	os.Setenv("https_proxy", "http://proxy.example:3128")
+	os.Unsetenv("NO_PROXY")
+	os.Setenv("OPCTL_UNRELATED", "should-not-propagate")
+
+	env := daemonEnv()
+
+	has := func(s string) bool {
+		for _, e := range env {
+			if e == s {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !has("HTTP_PROXY=http://proxy.example:3128") {
+		t.Errorf("expected HTTP_PROXY to be passed through; got %v", env)
+	}
+	if !has("https_proxy=http://proxy.example:3128") {
+		t.Errorf("expected https_proxy to be passed through; got %v", env)
+	}
+	for _, e := range env {
+		if e == "NO_PROXY=" {
+			t.Errorf("did not expect an unset NO_PROXY to be added; got %v", env)
+		}
+		if len(e) >= 15 && e[:15] == "OPCTL_UNRELATED" {
+			t.Errorf("did not expect arbitrary env to be inherited; got %v", env)
+		}
+	}
+}

--- a/sdks/go/node/containerruntime/docker/constructContainerConfig.go
+++ b/sdks/go/node/containerruntime/docker/constructContainerConfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
+	"github.com/opctl/opctl/sdks/go/node/containerruntime"
 )
 
 func constructContainerConfig(
@@ -31,6 +32,13 @@ func constructContainerConfig(
 	}
 
 	for envVarName, envVarValue := range envVars {
+		containerConfig.Env = append(containerConfig.Env, fmt.Sprintf("%v=%v", envVarName, envVarValue))
+	}
+
+	// propagate proxy env vars from the opctl node's process environment, without
+	// overriding values the op explicitly set, so containers can reach the network
+	// on hosts whose only egress route is an HTTP/HTTPS forward proxy.
+	for envVarName, envVarValue := range containerruntime.ProxyEnvVars(envVars) {
 		containerConfig.Env = append(containerConfig.Env, fmt.Sprintf("%v=%v", envVarName, envVarValue))
 	}
 	// sort binds to make order deterministic; useful for testing

--- a/sdks/go/node/containerruntime/docker/constructContainerConfig_test.go
+++ b/sdks/go/node/containerruntime/docker/constructContainerConfig_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/docker/docker/api/types/container"
@@ -11,9 +12,47 @@ import (
 )
 
 var _ = Context("constructContainerConfig", func() {
+	It("should propagate proxy env vars from the node env without overriding op values", func() {
+		/* arrange */
+		os.Setenv("HTTP_PROXY", "http://node-proxy:3128")
+		os.Setenv("NO_PROXY", "localhost")
+		defer os.Unsetenv("HTTP_PROXY")
+		defer os.Unsetenv("NO_PROXY")
+
+		/* act */
+		actualResult := constructContainerConfig(
+			[]string{"dummyCmd"},
+			map[string]string{
+				// op explicitly sets HTTP_PROXY; it must win over the node env
+				"HTTP_PROXY": "http://op-proxy:8080",
+			},
+			"dummyImageRef",
+			nat.PortMap{},
+			"dummyWorkDir",
+		)
+
+		/* assert */
+		Expect(actualResult.Env).To(ContainElement("HTTP_PROXY=http://op-proxy:8080"))
+		Expect(actualResult.Env).NotTo(ContainElement("HTTP_PROXY=http://node-proxy:3128"))
+		Expect(actualResult.Env).To(ContainElement("NO_PROXY=localhost"))
+	})
+
 	It("should return expected result", func() {
 
 		/* arrange */
+		// ensure the host's proxy env can't perturb the deterministic expectation
+		for _, name := range []string{
+			"HTTP_PROXY", "http_proxy",
+			"HTTPS_PROXY", "https_proxy",
+			"NO_PROXY", "no_proxy",
+			"ALL_PROXY", "all_proxy",
+		} {
+			if prev, had := os.LookupEnv(name); had {
+				os.Unsetenv(name)
+				defer os.Setenv(name, prev)
+			}
+		}
+
 		providedCmd := []string{
 			"dummyCmd",
 		}

--- a/sdks/go/node/containerruntime/k8s/constructPod.go
+++ b/sdks/go/node/containerruntime/k8s/constructPod.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/node/containerruntime"
 	coreV1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,6 +37,19 @@ func constructPod(
 	}
 
 	for envVarName, envVarValue := range req.EnvVars {
+		container.Env = append(
+			container.Env,
+			coreV1.EnvVar{
+				Name:  envVarName,
+				Value: envVarValue,
+			},
+		)
+	}
+
+	// propagate proxy env vars from the opctl node's process environment, without
+	// overriding values the op explicitly set, so containers can reach the network
+	// on hosts whose only egress route is an HTTP/HTTPS forward proxy.
+	for envVarName, envVarValue := range containerruntime.ProxyEnvVars(req.EnvVars) {
 		container.Env = append(
 			container.Env,
 			coreV1.EnvVar{

--- a/sdks/go/node/containerruntime/proxyEnv.go
+++ b/sdks/go/node/containerruntime/proxyEnv.go
@@ -1,0 +1,39 @@
+package containerruntime
+
+import "os"
+
+// proxyEnvVarNames are the proxy related environment variables opctl propagates
+// from its own process environment into containers it runs. Both the uppercase
+// and lowercase forms are propagated, since programs differ in which form they
+// honor.
+var proxyEnvVarNames = []string{
+	"HTTP_PROXY", "http_proxy",
+	"HTTPS_PROXY", "https_proxy",
+	"NO_PROXY", "no_proxy",
+	"ALL_PROXY", "all_proxy",
+}
+
+// ProxyEnvVars returns proxy related environment variables present in the opctl
+// node's own process environment which are not already set in opEnvVars.
+//
+// This lets containers reach the network on hosts where the only egress route
+// is an HTTP/HTTPS forward proxy (e.g. CI runners behind a proxy). Because
+// opctl talks to the container runtime via its SDK rather than the docker CLI,
+// the `~/.docker/config.json` proxies convenience does not apply, so opctl must
+// inject these itself.
+//
+// Values explicitly provided by an op are never overridden; only proxy
+// variables absent from opEnvVars are returned.
+func ProxyEnvVars(opEnvVars map[string]string) map[string]string {
+	propagated := map[string]string{}
+	for _, name := range proxyEnvVarNames {
+		if _, ok := opEnvVars[name]; ok {
+			// never clobber an op-declared value
+			continue
+		}
+		if value, ok := os.LookupEnv(name); ok {
+			propagated[name] = value
+		}
+	}
+	return propagated
+}

--- a/sdks/go/node/containerruntime/proxyEnv_test.go
+++ b/sdks/go/node/containerruntime/proxyEnv_test.go
@@ -1,0 +1,65 @@
+package containerruntime
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestProxyEnvVars(t *testing.T) {
+	t.Run("proxy vars in the node env are added to the container env", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTP_PROXY", "http://proxy:3128")
+		t.Setenv("https_proxy", "http://proxy:3129")
+
+		actual := ProxyEnvVars(map[string]string{})
+
+		expected := map[string]string{
+			"HTTP_PROXY":  "http://proxy:3128",
+			"https_proxy": "http://proxy:3129",
+		}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Fatalf("expected %v, got %v", expected, actual)
+		}
+	})
+
+	t.Run("an op-provided value for the same key is not overridden", func(t *testing.T) {
+		clearProxyEnv(t)
+		t.Setenv("HTTP_PROXY", "http://node-proxy:3128")
+
+		actual := ProxyEnvVars(map[string]string{
+			"HTTP_PROXY": "http://op-proxy:8080",
+		})
+
+		if len(actual) != 0 {
+			t.Fatalf("expected op-provided HTTP_PROXY to be left untouched, got %v", actual)
+		}
+	})
+
+	t.Run("when no proxy vars are set the result is empty", func(t *testing.T) {
+		clearProxyEnv(t)
+
+		actual := ProxyEnvVars(map[string]string{
+			"SOME_OTHER_VAR": "value",
+		})
+
+		if len(actual) != 0 {
+			t.Fatalf("expected no propagated vars, got %v", actual)
+		}
+	})
+}
+
+// clearProxyEnv unsets every proxy env var so the host's own environment cannot
+// influence the result, restoring prior values when the test completes.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range proxyEnvVarNames {
+		prev, had := os.LookupEnv(name)
+		if had {
+			t.Cleanup(func() { os.Setenv(name, prev) })
+		} else {
+			t.Cleanup(func() { os.Unsetenv(name) })
+		}
+		os.Unsetenv(name)
+	}
+}


### PR DESCRIPTION
## Problem

opctl runs ops as containers via the container runtime's SDK (e.g. the Docker Go SDK), not the `docker` CLI. On hosts whose only egress route to the internet is an HTTP/HTTPS **forward proxy** (e.g. AWS CodeBuild runners, or any CI behind a corporate proxy, with no direct/NAT route), the processes inside op containers — `go mod download`, `apt-get`, `curl`, etc. — need `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / `ALL_PROXY` in their environment to reach the network.

Today opctl does not propagate these, so those containers run with no proxy configuration and their network calls hang or fail.

Because opctl talks to the daemon via the SDK rather than the CLI, the usual `~/.docker/config.json` `proxies` convenience does **not** apply here — opctl has to inject the variables itself.

(The image *pull* is a separate, daemon-side concern and is intentionally out of scope.)

## Change

Add a small shared helper `containerruntime.ProxyEnvVars` that, given the op-provided env map, returns the proxy related variables present in the **opctl node's own process environment** that the op did **not** already set:

- Variables propagated: `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY` and their lowercase forms.
- Non-override rule: if the op explicitly set a key, the node value is **never** added/clobbered for that key.
- When no proxy vars are present in the node env, the container env is unchanged.

It's wired into both runtimes:

- **Docker**: `sdks/go/node/containerruntime/docker/constructContainerConfig.go`
- **Kubernetes**: `sdks/go/node/containerruntime/k8s/constructPod.go`

## Tests

- `sdks/go/node/containerruntime/proxyEnv_test.go` (`TestProxyEnvVars`) covers: (a) node-env proxy vars are propagated, (b) op-provided values are not overridden, (c) no proxy vars => empty result. Uses save/restore of env so the host environment can't perturb results.
- An added Ginkgo spec in `constructContainerConfig_test.go` asserts propagation flows into `container.Config.Env` and that an op-set `HTTP_PROXY` wins. The existing exact-match spec was made deterministic by clearing proxy vars for its duration.

`go build ./node/containerruntime/...` and `go test ./node/containerruntime/` pass.