### PR TITLE
feat(containerruntime): add containerd runtime backend via nerdctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file in
 accordance with
 [![keepachangelog 1.0.0](https://img.shields.io/badge/keepachangelog-1.0.0-brightgreen.svg)](http://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+
+### Added
+
+- New `containerd` container runtime (`--container-runtime containerd`), which drives containerd via the
+`nerdctl` CLI. Unlike the docker runtime it supports per-registry mirrors (`hosts.toml`), letting Docker Hub
+**and** Quay pulls be transparently redirected through a pull-through cache; registry auth is resolved by
+containerd/nerdctl host config rather than per-op `pullCreds`. The default runtime is unchanged. See
+`sdks/go/node/containerruntime/containerd/README.md`.
+
 ## [0.1.76] - 2026-06-18
 
 ### Added

--- a/cli/cmd/node/getContainerRuntime.go
+++ b/cli/cmd/node/getContainerRuntime.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/opctl/opctl/cli/internal/nodeprovider/local"
 	"github.com/opctl/opctl/sdks/go/node/containerruntime"
+	"github.com/opctl/opctl/sdks/go/node/containerruntime/containerd"
 	"github.com/opctl/opctl/sdks/go/node/containerruntime/docker"
 	"github.com/opctl/opctl/sdks/go/node/containerruntime/embedded"
 	"github.com/opctl/opctl/sdks/go/node/containerruntime/k8s"
@@ -18,6 +19,8 @@ func getContainerRuntime(
 		return k8s.New()
 	} else if nodeConfig.ContainerRuntime == "embedded" {
 		return embedded.New(ctx, nodeConfig.DataDir)
+	} else if nodeConfig.ContainerRuntime == "containerd" {
+		return containerd.New()
 	} else {
 		return docker.New(ctx, "unix:///var/run/docker.sock")
 	}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -215,7 +215,7 @@ func NewRootCmd() (*cobra.Command, error) {
 			&nodeConfig.ContainerRuntime,
 			"container-runtime",
 			"docker",
-			"Runtime for opctl containers. Can be 'docker' (deprecated), 'k8s', or 'embedded'",
+			"Runtime for opctl containers. Can be 'docker' (deprecated), 'containerd', 'k8s', or 'embedded'",
 		)
 
 	rootCmd.

--- a/sdks/go/node/containerruntime/containerd/README.md
+++ b/sdks/go/node/containerruntime/containerd/README.md
@@ -1,0 +1,194 @@
+# containerd container runtime
+
+This backend implements opctl's `ContainerRuntime` by driving **containerd**
+through the [`nerdctl`](https://github.com/containerd/nerdctl) CLI. Select it with:
+
+```sh
+opctl --container-runtime containerd ...
+```
+
+The default runtime remains `docker`, so enabling this backend is opt-in and
+leaves existing dockerd-based nodes/jobs untouched — the `--container-runtime`
+flag value *is* the feature flag.
+
+## Why containerd instead of dockerd
+
+The Docker daemon's `registry-mirrors` only mirrors **Docker Hub**. It cannot
+transparently redirect pulls for other registries (e.g. `quay.io`). containerd
+supports **per-registry mirrors** via `hosts.toml`, which lets you redirect both
+Docker Hub *and* Quay pulls through a single pull-through cache (PTC) without
+rewriting any image refs in `op.yml`.
+
+## How it differs from the docker backend
+
+| Concern | docker backend | containerd backend |
+|---|---|---|
+| Transport | Docker Engine API over a socket | shells out to `nerdctl` |
+| Registry mirrors | dockerd `registry-mirrors` (Hub only) | `hosts.toml` per registry (any registry) |
+| Registry auth | per-op `pullCreds`, else dockerd config | containerd/nerdctl host config (`hosts.toml` + docker `config.json` cred helpers) |
+| stdout/stderr | TTY | separate streams (no TTY) |
+
+> **Auth note:** this backend does **not** use per-op `image.pullCreds`. Registry
+> credentials are resolved by containerd/nerdctl host configuration (see
+> [Registry auth](#registry-auth-ecr-pull-through-cache) below). This is by design:
+> the whole point is that auth and mirroring are runner-level config, not per-op.
+>
+> **GPU note:** GPU passthrough auto-detection (a docker-backend feature) is not
+> implemented here.
+
+## Requirements
+
+- `containerd` running on the host.
+- `nerdctl` on `PATH` (or point opctl at it with `$OPCTL_NERDCTL=/path/to/nerdctl`).
+- The CNI plugins nerdctl needs for bridge networking + name resolution.
+- opctl running as root (rootful containerd), same as the docker backend.
+
+opctl fails fast at node start if `nerdctl` can't be found.
+
+## Registry mirrors (`hosts.toml`)
+
+Point containerd at a `certs.d` directory and add one `hosts.toml` per upstream
+registry. With our PTC in the artifact-archive prod account
+(`012473847565`, `us-west-2`) and PTC rules `docker-hub → registry-1.docker.io`
+and `quay → quay.io`:
+
+`/etc/containerd/certs.d/docker.io/hosts.toml`:
+
+```toml
+server = "https://registry-1.docker.io"
+
+[host."https://012473847565.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub"]
+  capabilities = ["pull", "resolve"]
+  # ECR's PTC path is /v2/docker-hub/<repo>; override_path stops containerd from
+  # appending the upstream repo path to a path that already encodes it.
+  override_path = true
+```
+
+`/etc/containerd/certs.d/quay.io/hosts.toml`:
+
+```toml
+server = "https://quay.io"
+
+[host."https://012473847565.dkr.ecr.us-west-2.amazonaws.com/v2/quay"]
+  capabilities = ["pull", "resolve"]
+  override_path = true
+```
+
+And ensure containerd's config references the directory
+(`/etc/containerd/config.toml`):
+
+```toml
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"
+```
+
+`nerdctl` also reads `/etc/containerd/certs.d` directly. This `override_path = true`
++ `/v2/<rule>` pattern is the configuration verified to work in
+[containerd discussion #11385](https://github.com/containerd/containerd/discussions/11385).
+
+Ready-to-copy versions of these files live in [`examples/`](examples).
+
+## Registry auth (ECR pull-through cache)
+
+The PTC registry is private ECR, so pulls must authenticate. **Preferred** is the
+[`docker-credential-ecr-login`](https://github.com/awslabs/amazon-ecr-credential-helper)
+helper, keyed to the ECR registry host in the docker config that nerdctl reads
+(`$DOCKER_CONFIG/config.json`, default `~/.docker/config.json`):
+
+```json
+{
+  "credHelpers": {
+    "012473847565.dkr.ecr.us-west-2.amazonaws.com": "ecr-login"
+  }
+}
+```
+
+**Auth-refresh mechanism:** ECR authorization tokens expire after 12 hours.
+`docker-credential-ecr-login` is invoked by nerdctl *on every pull* for the ECR
+host; it calls `ecr:GetAuthorizationToken` using the runner's AWS credential
+chain (its service role) and returns a fresh token (caching it until shortly
+before expiry). There is **no token to rotate manually** and nothing to schedule
+— keep the helper on `PATH` and the role's credentials available.
+
+Because pulls are redirected to the mirror host, nerdctl must attach these
+credentials to the **mirror host** (the ECR registry), not the original
+`docker.io`/`quay.io` host. Recent containerd/nerdctl do this — the resolver
+authenticates against the host it actually connects to. Verify on the target
+runner once:
+
+```sh
+nerdctl pull --debug-full docker.io/library/alpine:3.20 2>&1 \
+  | grep -i 'authorized\|012473847565.dkr.ecr'
+```
+
+**Fallback** (only if your nerdctl version does *not* apply host creds on the
+mirror path): put a static `Authorization` header in `hosts.toml` and refresh it
+out of band. ECR Basic auth is `base64("AWS:<token>")`:
+
+```toml
+[host."https://012473847565.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub".header]
+  Authorization = "Basic QVdTOjxFQ1IgdG9rZW4+"
+```
+
+Refresh it with a systemd timer (every ~6h, well inside the 12h expiry):
+
+```sh
+TOKEN="$(aws ecr get-login-password --region us-west-2)"
+AUTH="Basic $(printf 'AWS:%s' "$TOKEN" | base64 -w0)"
+# rewrite the Authorization line in each hosts.toml, then no daemon restart needed
+```
+
+## Proxy bypass (`NO_PROXY`)
+
+Our runners have no direct internet route; egress goes through a mandatory
+forward proxy. The ECR/S3 endpoints used by the PTC are reachable via interface
+VPC endpoints and **must bypass** the proxy, or pulls will fail. containerd and
+nerdctl honor `HTTPS_PROXY`/`NO_PROXY` from **their own** process environment,
+so set `NO_PROXY` on the **containerd service** (a systemd drop-in), not just in
+the build shell:
+
+```ini
+# /etc/systemd/system/containerd.service.d/http-proxy.conf
+[Service]
+Environment="HTTPS_PROXY=http://forward-proxy:3128"
+Environment="NO_PROXY=*.dkr.ecr.us-west-2.amazonaws.com,api.ecr.us-west-2.amazonaws.com,*.s3.us-west-2.amazonaws.com,localhost,127.0.0.1"
+```
+
+(opctl separately propagates `HTTP(S)_PROXY`/`NO_PROXY` from the node's env into
+the op containers it runs — see `containerruntime.ProxyEnvVars` — so workloads
+inside the containers also reach the network through the proxy.)
+
+## IAM (runner service role)
+
+The runner's service role needs:
+
+- `ecr:GetAuthorizationToken` on `*`
+- pull + `BatchImportUpstreamImage` on
+  `arn:aws:ecr:us-west-2:012473847565:repository/{docker-hub,quay}/*`
+
+See [`examples/iam-policy.json`](examples/iam-policy.json).
+
+## Runner wiring (codebuild-infra-pipeline)
+
+The opctl code change lives here; the runner-template change lives in
+`Remitly/codebuild-infra-pipeline`
+(`runners/default/cfn/gha-codebuild-runner.yaml`). Per the golden-pipeline
+sign-off norm, that change is proposed for review rather than landed silently.
+The runner's user-data / buildspec must, behind the same feature flag:
+
+1. Install `containerd`, `nerdctl`, CNI plugins, and `docker-credential-ecr-login`.
+2. Drop in the `certs.d/*/hosts.toml`, docker `config.json`, and containerd
+   `config.toml` from [`examples/`](examples).
+3. Add the `NO_PROXY` systemd drop-in above and `systemctl daemon-reload &&
+   systemctl restart containerd`.
+4. Attach the IAM policy delta to the runner service role.
+5. Run opctl with `--container-runtime containerd`.
+
+## Verifying (definition of done)
+
+1. Run an op whose image is a Docker Hub image and one whose image is a `quay.io`
+   image; both should pull and run.
+2. Confirm new repositories appear under `docker-hub/…` and `quay/…` in the
+   artifact-archive ECR (PTC populated them on first pull).
+3. Confirm runner egress logs show **no** connections to `registry-1.docker.io`
+   or `quay.io`.

--- a/sdks/go/node/containerruntime/containerd/constructCreateArgs_test.go
+++ b/sdks/go/node/containerruntime/containerd/constructCreateArgs_test.go
@@ -1,0 +1,146 @@
+package containerd
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+// clearProxyEnv removes proxy env vars for the duration of a test so
+// containerruntime.ProxyEnvVars (which reads the process env) doesn't make
+// constructCreateArgs results depend on the ambient environment.
+func clearProxyEnv() func() {
+	names := []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+		"ALL_PROXY", "all_proxy",
+	}
+	saved := map[string]string{}
+	for _, n := range names {
+		if v, ok := os.LookupEnv(n); ok {
+			saved[n] = v
+			os.Unsetenv(n)
+		}
+	}
+	return func() {
+		for n, v := range saved {
+			os.Setenv(n, v)
+		}
+	}
+}
+
+var _ = Context("constructCreateArgs", func() {
+	strPtr := func(s string) *string { return &s }
+
+	It("builds a deterministic, fully-populated arg vector", func() {
+		restore := clearProxyEnv()
+		defer restore()
+
+		req := &model.ContainerCall{
+			ContainerID: "cid",
+			Name:        strPtr("myname"),
+			WorkDir:     "/work",
+			Cmd:         []string{"echo", "hi"},
+			EnvVars:     map[string]string{"B": "2", "A": "1"},
+			Files:       map[string]string{"/f2": "/hostf2", "/f1": "/hostf1"},
+			Dirs:        map[string]string{"/d": "/hostd"},
+			// only the unix socket (value containing a path separator) is mounted
+			Sockets: map[string]string{"/sock": "/var/run/x.sock", "/tcp": "tcp:1234"},
+			Ports:   map[string]string{"8080": "9090"},
+			Image:   &model.ContainerCallImage{Ref: strPtr("alpine:3")},
+		}
+
+		args, err := constructCreateArgs(req, getContainerName(req.ContainerID))
+
+		Expect(err).To(BeNil())
+		Expect(args).To(Equal([]string{
+			"create",
+			"--name", "opctl_cid",
+			"--network", "opctl",
+			"--privileged",
+			"--network-alias", "myname",
+			"--workdir", "/work",
+			"--env", "A=1",
+			"--env", "B=2",
+			"--volume", "/hostf1:/f1",
+			"--volume", "/hostf2:/f2",
+			"--volume", "/hostd:/d",
+			"--volume", "/var/run/x.sock:/sock",
+			"--publish", "9090:8080",
+			"alpine:3",
+			"echo", "hi",
+		}))
+	})
+
+	It("omits optional flags when not set", func() {
+		restore := clearProxyEnv()
+		defer restore()
+
+		req := &model.ContainerCall{
+			ContainerID: "cid",
+			Image:       &model.ContainerCallImage{Ref: strPtr("alpine")},
+		}
+
+		args, err := constructCreateArgs(req, getContainerName(req.ContainerID))
+
+		Expect(err).To(BeNil())
+		Expect(args).To(Equal([]string{
+			"create",
+			"--name", "opctl_cid",
+			"--network", "opctl",
+			"--privileged",
+			"alpine",
+		}))
+	})
+
+	It("propagates proxy env vars without clobbering op-declared ones", func() {
+		restore := clearProxyEnv()
+		defer restore()
+		os.Setenv("HTTPS_PROXY", "http://proxy:3128")
+		os.Setenv("NO_PROXY", "from-env")
+
+		req := &model.ContainerCall{
+			ContainerID: "cid",
+			// op explicitly sets NO_PROXY; env value must not override it
+			EnvVars: map[string]string{"NO_PROXY": "from-op"},
+			Image:   &model.ContainerCallImage{Ref: strPtr("alpine")},
+		}
+
+		args, err := constructCreateArgs(req, getContainerName(req.ContainerID))
+
+		Expect(err).To(BeNil())
+		Expect(args).To(ContainElement("HTTPS_PROXY=http://proxy:3128"))
+		Expect(args).To(ContainElement("NO_PROXY=from-op"))
+		Expect(args).NotTo(ContainElement("NO_PROXY=from-env"))
+	})
+
+	It("errors when no image ref is provided", func() {
+		req := &model.ContainerCall{ContainerID: "cid", Image: &model.ContainerCallImage{}}
+		_, err := constructCreateArgs(req, getContainerName(req.ContainerID))
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Context("getContainerName", func() {
+	It("prefixes the container id", func() {
+		Expect(getContainerName("abc")).To(Equal("opctl_abc"))
+	})
+})
+
+var _ = Context("lastNonEmptyLine", func() {
+	It("returns the last non-empty trimmed line", func() {
+		Expect(lastNonEmptyLine("garbage\n0\n\n")).To(Equal("0"))
+		Expect(lastNonEmptyLine("137\n")).To(Equal("137"))
+	})
+})
+
+var _ = Context("isNotFound", func() {
+	It("detects nerdctl not-found output", func() {
+		Expect(isNotFound("Error: no such container: opctl_x")).To(BeTrue())
+		Expect(isNotFound("nerdctl: not found")).To(BeTrue())
+		Expect(isNotFound("some other error")).To(BeFalse())
+	})
+})

--- a/sdks/go/node/containerruntime/containerd/containerd.go
+++ b/sdks/go/node/containerruntime/containerd/containerd.go
@@ -1,0 +1,153 @@
+// Package containerd implements opctl's ContainerRuntime by driving containerd
+// through the nerdctl CLI.
+//
+// Unlike the docker backend (which speaks the Docker Engine API over a socket),
+// this backend shells out to `nerdctl`. That choice is deliberate: nerdctl
+// natively honors containerd's per-registry mirror configuration under
+// `/etc/containerd/certs.d/<host>/hosts.toml` and the credential helpers
+// configured in `~/.docker/config.json` (e.g. docker-credential-ecr-login).
+// This lets registry pulls (Docker Hub, Quay, ...) be transparently redirected
+// through a pull-through cache without any per-op image-ref changes, which the
+// Docker daemon's Hub-only `registry-mirrors` setting cannot do.
+//
+// Registry authentication is therefore resolved by containerd/nerdctl host
+// config rather than by per-op `pullCreds`; see the README for details.
+package containerd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/opctl/opctl/sdks/go/node/containerruntime"
+)
+
+// containerNamePrefix is prepended to every opctl managed container so external
+// tooling (and our own Delete/Kill enumeration) can recognize them. Kept
+// identical to the docker backend's prefix on purpose.
+const containerNamePrefix = "opctl_"
+
+// networkName is the bridge network opctl containers are attached to so they can
+// resolve one another by name.
+const networkName = "opctl"
+
+// New returns a ContainerRuntime backed by containerd via the nerdctl CLI.
+//
+// The nerdctl binary is resolved from $OPCTL_NERDCTL when set, otherwise from
+// the first `nerdctl` found on PATH. New fails fast if the binary can't be
+// located so misconfiguration surfaces at node start rather than at first run.
+func New() (containerruntime.ContainerRuntime, error) {
+	nerdctlPath := os.Getenv("OPCTL_NERDCTL")
+	if nerdctlPath == "" {
+		nerdctlPath = "nerdctl"
+	}
+
+	resolved, err := exec.LookPath(nerdctlPath)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"containerd runtime requires the nerdctl CLI; %q not found on PATH (set $OPCTL_NERDCTL to override): %w",
+			nerdctlPath,
+			err,
+		)
+	}
+
+	return _containerRuntime{nerdctlPath: resolved}, nil
+}
+
+type _containerRuntime struct {
+	nerdctlPath string
+}
+
+// nerdctl runs a nerdctl subcommand to completion, returning combined output.
+func (cr _containerRuntime) nerdctl(
+	ctx context.Context,
+	args ...string,
+) (string, error) {
+	cmd := exec.CommandContext(ctx, cr.nerdctlPath, args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	return out.String(), err
+}
+
+// getContainerName converts an opctl container id into the nerdctl container
+// name (prefixed so it's recognizable as opctl managed).
+func getContainerName(opctlContainerID string) string {
+	return fmt.Sprintf("%s%s", containerNamePrefix, opctlContainerID)
+}
+
+func (cr _containerRuntime) DeleteContainerIfExists(
+	ctx context.Context,
+	containerID string,
+) error {
+	// `rm -f` removes a running or stopped container; a missing container is not
+	// an error we care about here, mirroring the docker backend's best-effort
+	// cleanup semantics.
+	if out, err := cr.nerdctl(ctx, "rm", "-f", getContainerName(containerID)); err != nil {
+		if isNotFound(out) {
+			return nil
+		}
+		return fmt.Errorf("unable to delete container: %w, %s", err, out)
+	}
+	return nil
+}
+
+// Delete removes all opctl managed containers and the opctl network.
+func (cr _containerRuntime) Delete(
+	ctx context.Context,
+) error {
+	names, err := cr.opctlContainerNames(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range names {
+		if out, err := cr.nerdctl(ctx, "rm", "-f", name); err != nil && !isNotFound(out) {
+			return fmt.Errorf("unable to delete container %q: %w, %s", name, err, out)
+		}
+	}
+
+	// Remove the network last; failures (not found, or still in use by a racing
+	// container) are non-fatal since the network is recreated on demand.
+	cr.nerdctl(ctx, "network", "rm", networkName)
+
+	return nil
+}
+
+// Kill is equivalent to Delete for this backend (containers are stopped as part
+// of removal), matching the docker backend.
+func (cr _containerRuntime) Kill(
+	ctx context.Context,
+) error {
+	return cr.Delete(ctx)
+}
+
+// opctlContainerNames lists the names of all opctl managed containers.
+func (cr _containerRuntime) opctlContainerNames(
+	ctx context.Context,
+) ([]string, error) {
+	out, err := cr.nerdctl(ctx, "ps", "--all", "--format", "{{.Names}}")
+	if err != nil {
+		return nil, fmt.Errorf("unable to list containers: %w, %s", err, out)
+	}
+
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		name := strings.TrimSpace(line)
+		if strings.HasPrefix(name, containerNamePrefix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// isNotFound reports whether nerdctl output indicates a benign "no such object"
+// condition (the object we asked to remove was already gone).
+func isNotFound(output string) bool {
+	msg := strings.ToLower(output)
+	return strings.Contains(msg, "no such") || strings.Contains(msg, "not found")
+}

--- a/sdks/go/node/containerruntime/containerd/examples/certs.d/docker.io/hosts.toml
+++ b/sdks/go/node/containerruntime/containerd/examples/certs.d/docker.io/hosts.toml
@@ -1,0 +1,11 @@
+# /etc/containerd/certs.d/docker.io/hosts.toml
+#
+# Redirects Docker Hub pulls through the ECR pull-through cache (PTC) in the
+# artifact-archive prod account. PTC rule: docker-hub -> registry-1.docker.io.
+server = "https://registry-1.docker.io"
+
+[host."https://012473847565.dkr.ecr.us-west-2.amazonaws.com/v2/docker-hub"]
+  capabilities = ["pull", "resolve"]
+  # The PTC repo path is /v2/docker-hub/<repo>; override_path keeps containerd
+  # from appending the upstream repo path to a path that already encodes it.
+  override_path = true

--- a/sdks/go/node/containerruntime/containerd/examples/certs.d/quay.io/hosts.toml
+++ b/sdks/go/node/containerruntime/containerd/examples/certs.d/quay.io/hosts.toml
@@ -1,0 +1,9 @@
+# /etc/containerd/certs.d/quay.io/hosts.toml
+#
+# Redirects Quay pulls through the ECR pull-through cache (PTC) in the
+# artifact-archive prod account. PTC rule: quay -> quay.io.
+server = "https://quay.io"
+
+[host."https://012473847565.dkr.ecr.us-west-2.amazonaws.com/v2/quay"]
+  capabilities = ["pull", "resolve"]
+  override_path = true

--- a/sdks/go/node/containerruntime/containerd/examples/containerd-config.toml
+++ b/sdks/go/node/containerruntime/containerd/examples/containerd-config.toml
@@ -1,0 +1,6 @@
+# Snippet for /etc/containerd/config.toml — point containerd at the certs.d
+# directory that holds the per-registry hosts.toml mirror config. nerdctl reads
+# /etc/containerd/certs.d directly; this also wires it up for the CRI image
+# service. Merge into the existing config; restart containerd after changes.
+[plugins."io.containerd.grpc.v1.cri".registry]
+  config_path = "/etc/containerd/certs.d"

--- a/sdks/go/node/containerruntime/containerd/examples/containerd.service.d/http-proxy.conf
+++ b/sdks/go/node/containerruntime/containerd/examples/containerd.service.d/http-proxy.conf
@@ -1,0 +1,11 @@
+# /etc/systemd/system/containerd.service.d/http-proxy.conf
+#
+# containerd performs the registry pulls, so it (not just the build shell) must
+# know to bypass the mandatory forward proxy for the ECR/S3 VPC endpoints, which
+# are reachable directly. Without NO_PROXY here, pulls to the PTC fail.
+#
+# After installing: `systemctl daemon-reload && systemctl restart containerd`.
+[Service]
+Environment="HTTP_PROXY=http://forward-proxy:3128"
+Environment="HTTPS_PROXY=http://forward-proxy:3128"
+Environment="NO_PROXY=*.dkr.ecr.us-west-2.amazonaws.com,api.ecr.us-west-2.amazonaws.com,*.s3.us-west-2.amazonaws.com,localhost,127.0.0.1"

--- a/sdks/go/node/containerruntime/containerd/examples/docker-config.json
+++ b/sdks/go/node/containerruntime/containerd/examples/docker-config.json
@@ -1,0 +1,6 @@
+{
+  "comment": "Install at $DOCKER_CONFIG/config.json (default ~/.docker/config.json) for the user containerd/nerdctl runs as. Requires docker-credential-ecr-login on PATH. nerdctl invokes it per-pull; it fetches a fresh ECR token via the runner's AWS credential chain, so there is nothing to rotate.",
+  "credHelpers": {
+    "012473847565.dkr.ecr.us-west-2.amazonaws.com": "ecr-login"
+  }
+}

--- a/sdks/go/node/containerruntime/containerd/examples/iam-policy.json
+++ b/sdks/go/node/containerruntime/containerd/examples/iam-policy.json
@@ -1,0 +1,25 @@
+{
+  "Comment": "IAM policy delta for the runner service role: lets containerd/nerdctl authenticate to ECR and pull (importing upstream images on demand) from the docker-hub and quay PTC repositories in the artifact-archive prod account.",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EcrAuth",
+      "Effect": "Allow",
+      "Action": "ecr:GetAuthorizationToken",
+      "Resource": "*"
+    },
+    {
+      "Sid": "EcrPullThroughCachePull",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:BatchGetImage",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchImportUpstreamImage"
+      ],
+      "Resource": [
+        "arn:aws:ecr:us-west-2:012473847565:repository/docker-hub/*",
+        "arn:aws:ecr:us-west-2:012473847565:repository/quay/*"
+      ]
+    }
+  ]
+}

--- a/sdks/go/node/containerruntime/containerd/loadImage.go
+++ b/sdks/go/node/containerruntime/containerd/loadImage.go
@@ -1,0 +1,66 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containers/image/v5/copy"
+	"github.com/containers/image/v5/oci/archive"
+	"github.com/containers/image/v5/oci/layout"
+	"github.com/containers/image/v5/signature"
+	"github.com/opctl/opctl/sdks/go/model"
+)
+
+// loadImage imports an op-provided image (req.Image.Src, an OCI layout dir) into
+// containerd and points req.Image.Ref at the loaded tag. It is the containerd
+// analogue of the docker backend's pushImage: rather than pushing to a daemon,
+// it copies the OCI layout into an OCI archive and `nerdctl load`s it.
+func (cr _containerRuntime) loadImage(
+	ctx context.Context,
+	req *model.ContainerCall,
+) error {
+	imageRef := fmt.Sprintf("%s:latest", req.ContainerID)
+	req.Image.Ref = &imageRef
+
+	tmp, err := os.CreateTemp("", "opctl-image-*.tar")
+	if err != nil {
+		return fmt.Errorf("error loading image: %w", err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close()
+	defer os.Remove(tmpPath)
+
+	policyCtx, err := signature.NewPolicyContext(
+		&signature.Policy{
+			Default: []signature.PolicyRequirement{
+				signature.NewPRInsecureAcceptAnything(),
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("error loading image: %w", err)
+	}
+
+	srcImageRef, err := layout.NewReference(*req.Image.Src.Dir, "")
+	if err != nil {
+		return fmt.Errorf("error loading image: %w", err)
+	}
+
+	// oci-archive reference format is "path:tag"; the temp path has no colon, so
+	// the tag (imageRef) is preserved intact when nerdctl loads the archive.
+	dstImageRef, err := archive.ParseReference(fmt.Sprintf("%s:%s", tmpPath, imageRef))
+	if err != nil {
+		return fmt.Errorf("error loading image: %w", err)
+	}
+
+	if _, err := copy.Image(ctx, policyCtx, dstImageRef, srcImageRef, nil); err != nil {
+		return fmt.Errorf("error loading image: %w", err)
+	}
+
+	if out, err := cr.nerdctl(ctx, "load", "--input", tmpPath); err != nil {
+		return fmt.Errorf("error loading image: %w, %s", err, out)
+	}
+
+	return nil
+}

--- a/sdks/go/node/containerruntime/containerd/pullImage.go
+++ b/sdks/go/node/containerruntime/containerd/pullImage.go
@@ -1,0 +1,77 @@
+package containerd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/distribution/reference"
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/node/pubsub"
+)
+
+// pullImage pulls the call's image via nerdctl, streaming progress to the event
+// publisher. Registry auth and mirror redirection are resolved by
+// containerd/nerdctl host config (`/etc/containerd/certs.d/<host>/hosts.toml`
+// and `~/.docker/config.json` credential helpers) rather than per-op pullCreds.
+func (cr _containerRuntime) pullImage(
+	ctx context.Context,
+	req *model.ContainerCall,
+	rootCallID string,
+	eventPublisher pubsub.EventPublisher,
+) error {
+	imageRef := *req.Image.Ref
+
+	if !cr.needsPull(ctx, imageRef) {
+		eventPublisher.Publish(model.Event{
+			Timestamp: time.Now().UTC(),
+			ContainerStdOutWrittenTo: &model.ContainerStdOutWrittenTo{
+				Data:        []byte(fmt.Sprintf("Skipping image pull: %s\n", imageRef)),
+				OpRef:       req.OpPath,
+				ContainerID: req.ContainerID,
+				RootCallID:  rootCallID,
+			},
+		})
+		return nil
+	}
+
+	args := []string{"pull"}
+	if req.Image.Platform != nil && req.Image.Platform.Arch != nil {
+		args = append(args, "--platform", fmt.Sprintf("linux/%s", *req.Image.Platform.Arch))
+	}
+	args = append(args, imageRef)
+
+	stdOutWriter := newStdOutWriteCloser(eventPublisher, req.ContainerID, rootCallID)
+	defer stdOutWriter.Close()
+
+	cmd := exec.CommandContext(ctx, cr.nerdctlPath, args...)
+	cmd.Stdout = stdOutWriter
+	cmd.Stderr = stdOutWriter
+	return cmd.Run()
+}
+
+// needsPull mirrors the docker backend: a tagged, non-"latest" image that's
+// already present locally is not re-pulled. This reduces registry round-trips
+// (and rate-limit exposure) and speeds up execution.
+func (cr _containerRuntime) needsPull(
+	ctx context.Context,
+	imageRef string,
+) bool {
+	ref, err := reference.ParseAnyReference(strings.ToLower(imageRef))
+	if err != nil {
+		return true
+	}
+	named, err := reference.ParseNormalizedNamed(ref.String())
+	if err != nil {
+		return true
+	}
+	if tagged, ok := named.(reference.Tagged); ok && tagged.Tag() != "latest" {
+		if _, err := cr.nerdctl(ctx, "image", "inspect", imageRef); err == nil {
+			return false
+		}
+		// inspect error is expected when the image isn't present; fall through
+	}
+	return true
+}

--- a/sdks/go/node/containerruntime/containerd/runContainer.go
+++ b/sdks/go/node/containerruntime/containerd/runContainer.go
@@ -1,0 +1,255 @@
+package containerd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/node/containerruntime"
+	"github.com/opctl/opctl/sdks/go/node/dns"
+	"github.com/opctl/opctl/sdks/go/node/pubsub"
+	"golang.org/x/sync/errgroup"
+)
+
+// RunContainer creates, starts, and waits on a container, returning its exit
+// code and/or an error. It mirrors the docker backend's lifecycle (ensure
+// network, pull/load image, create, start, stream stdout/stderr, register DNS
+// for named containers, wait) but drives containerd via nerdctl.
+func (cr _containerRuntime) RunContainer(
+	ctx context.Context,
+	req *model.ContainerCall,
+	rootCallID string,
+	eventPublisher pubsub.EventPublisher,
+	stdout io.WriteCloser,
+	stderr io.WriteCloser,
+) (*int64, error) {
+	defer stdout.Close()
+	defer stderr.Close()
+
+	// ensure the opctl network exists so named containers resolve one another
+	if err := cr.ensureNetworkExists(ctx); err != nil {
+		return nil, err
+	}
+
+	name := getContainerName(req.ContainerID)
+
+	// remove any stale container left behind by a prior run sharing this id
+	cr.nerdctl(context.Background(), "rm", "-f", name)
+	defer func() {
+		// always clean up, even after cancellation, using a fresh context
+		cr.nerdctl(context.Background(), "rm", "-f", name)
+	}()
+
+	var imageErr error
+	if req.Image.Src != nil {
+		imageErr = cr.loadImage(ctx, req)
+	} else {
+		// don't err yet; the image might be cached, which we allow for offline use
+		imageErr = cr.pullImage(ctx, req, rootCallID, eventPublisher)
+	}
+
+	createArgs, err := constructCreateArgs(req, name)
+	if err != nil {
+		return nil, errors.Join(imageErr, err)
+	}
+
+	if out, createErr := cr.nerdctl(ctx, createArgs...); createErr != nil {
+		select {
+		case <-ctx.Done():
+			// we got killed
+			return nil, nil
+		default:
+			return nil, errors.Join(imageErr, fmt.Errorf("unable to create container: %w, %s", createErr, out))
+		}
+	}
+
+	if out, err := cr.nerdctl(ctx, "start", name); err != nil {
+		return nil, fmt.Errorf("unable to start container: %w, %s", err, out)
+	}
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return cr.streamLogs(egCtx, name, stdout, stderr)
+	})
+
+	// register named containers with opctl's DNS so they're resolvable by name
+	if req.Name != nil {
+		ip, err := cr.containerIP(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		if ip != "" {
+			defer dns.UnregisterName(*req.Name, ip)
+			if err := dns.RegisterName(ctx, *req.Name, ip); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	exitCode, waitErr := cr.waitContainer(ctx, name)
+
+	// ensure all stdout/stderr is read before returning
+	logErr := eg.Wait()
+
+	return exitCode, errors.Join(waitErr, logErr)
+}
+
+// ensureNetworkExists creates the opctl bridge network, tolerating the common
+// case where it already exists (and races between concurrent container starts).
+func (cr _containerRuntime) ensureNetworkExists(
+	ctx context.Context,
+) error {
+	out, err := cr.nerdctl(ctx, "network", "create", networkName)
+	if err != nil && !strings.Contains(strings.ToLower(out), "already exists") {
+		return fmt.Errorf("unable to create network: %w, %s", err, out)
+	}
+	return nil
+}
+
+// constructCreateArgs builds the `nerdctl create` argument vector for a
+// container call. Ordering of env vars, mounts, and ports is sorted so the
+// result is deterministic (and testable).
+func constructCreateArgs(
+	req *model.ContainerCall,
+	name string,
+) ([]string, error) {
+	args := []string{
+		"create",
+		"--name", name,
+		"--network", networkName,
+		// support docker-in-docker, matching the docker backend's HostConfig
+		"--privileged",
+	}
+
+	if req.Name != nil {
+		// network alias makes the container resolvable by its op-declared name
+		args = append(args, "--network-alias", *req.Name)
+	}
+
+	if req.WorkDir != "" {
+		args = append(args, "--workdir", req.WorkDir)
+	}
+
+	// env vars: op-declared values plus propagated proxy vars (proxy vars never
+	// clobber op-declared ones; see containerruntime.ProxyEnvVars).
+	env := map[string]string{}
+	for k, v := range req.EnvVars {
+		env[k] = v
+	}
+	for k, v := range containerruntime.ProxyEnvVars(req.EnvVars) {
+		env[k] = v
+	}
+	for _, k := range sortedKeys(env) {
+		args = append(args, "--env", fmt.Sprintf("%s=%s", k, env[k]))
+	}
+
+	// bind mounts: files, then dirs, then sockets (matching the docker backend),
+	// each group sorted by container path for determinism.
+	for _, containerPath := range sortedKeys(req.Files) {
+		args = append(args, "--volume", fmt.Sprintf("%s:%s", req.Files[containerPath], containerPath))
+	}
+	for _, containerPath := range sortedKeys(req.Dirs) {
+		args = append(args, "--volume", fmt.Sprintf("%s:%s", req.Dirs[containerPath], containerPath))
+	}
+	for _, containerSocket := range sortedKeys(req.Sockets) {
+		hostSocket := req.Sockets[containerSocket]
+		// only unix sockets (identified naively by a path separator) are bind
+		// mounted, matching the docker backend.
+		if strings.ContainsAny(hostSocket, `/\`) {
+			args = append(args, "--volume", fmt.Sprintf("%s:%s", hostSocket, containerSocket))
+		}
+	}
+
+	// port bindings: hostPort:containerPort
+	for _, containerPort := range sortedKeys(req.Ports) {
+		args = append(args, "--publish", fmt.Sprintf("%s:%s", req.Ports[containerPort], containerPort))
+	}
+
+	if req.Image == nil || req.Image.Ref == nil {
+		return nil, errors.New("image ref is required")
+	}
+	args = append(args, *req.Image.Ref)
+	args = append(args, req.Cmd...)
+
+	return args, nil
+}
+
+// streamLogs follows the container's logs, writing stdout and stderr to the
+// supplied writers. nerdctl demultiplexes the two streams (the container is not
+// allocated a TTY), so they stay separated. Errors are treated as benign: the
+// container may already be gone, or the context cancelled.
+func (cr _containerRuntime) streamLogs(
+	ctx context.Context,
+	name string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	cmd := exec.CommandContext(ctx, cr.nerdctlPath, "logs", "--follow", name)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Run()
+	return nil
+}
+
+// containerIP returns the container's IP on the opctl network.
+func (cr _containerRuntime) containerIP(
+	ctx context.Context,
+	name string,
+) (string, error) {
+	out, err := cr.nerdctl(
+		ctx,
+		"inspect",
+		"--format", "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}",
+		name,
+	)
+	if err != nil {
+		return "", fmt.Errorf("unable to inspect container: %w, %s", err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// waitContainer blocks until the container exits and returns its exit code.
+func (cr _containerRuntime) waitContainer(
+	ctx context.Context,
+	name string,
+) (*int64, error) {
+	out, err := cr.nerdctl(ctx, "wait", name)
+	if err != nil {
+		if ctx.Err() != nil {
+			// killed; not a real wait failure
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error waiting on container: %w, %s", err, out)
+	}
+
+	exitCode, parseErr := strconv.ParseInt(lastNonEmptyLine(out), 10, 64)
+	if parseErr != nil {
+		return nil, fmt.Errorf("unable to parse container exit code from %q: %w", out, parseErr)
+	}
+	return &exitCode, nil
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/sdks/go/node/containerruntime/containerd/stdOutWriteCloser.go
+++ b/sdks/go/node/containerruntime/containerd/stdOutWriteCloser.go
@@ -1,0 +1,50 @@
+package containerd
+
+import (
+	"bufio"
+	"io"
+	"time"
+
+	"github.com/opctl/opctl/sdks/go/model"
+	"github.com/opctl/opctl/sdks/go/node/pubsub"
+)
+
+// newStdOutWriteCloser returns an io.WriteCloser that republishes everything
+// written to it as ContainerStdOutWrittenTo events (chunked on newlines). Used
+// to surface `nerdctl pull` progress through opctl's event stream, mirroring
+// the docker backend's writer.
+func newStdOutWriteCloser(
+	eventPublisher pubsub.EventPublisher,
+	containerID string,
+	rootCallID string,
+) io.WriteCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		// support lines up to 4MB
+		reader := bufio.NewReaderSize(pr, 4e6)
+		var err error
+		var b []byte
+
+		for {
+			// chunk on newlines
+			if b, err = reader.ReadBytes('\n'); len(b) > 0 {
+				eventPublisher.Publish(
+					model.Event{
+						Timestamp: time.Now().UTC(),
+						ContainerStdOutWrittenTo: &model.ContainerStdOutWrittenTo{
+							Data:        b,
+							ContainerID: containerID,
+							RootCallID:  rootCallID,
+						},
+					},
+				)
+			}
+
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	return pw
+}

--- a/sdks/go/node/containerruntime/containerd/suite_test.go
+++ b/sdks/go/node/containerruntime/containerd/suite_test.go
@@ -1,0 +1,13 @@
+package containerd
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "node/core/containerruntime/containerd")
+}

--- a/website/docs/setup.md
+++ b/website/docs/setup.md
@@ -139,7 +139,14 @@ import TabItem from '@theme/TabItem';
     |container runtime|dependencies|
     |--|--|
     |docker|[docker](https://docs.docker.com/get-docker/)|
+    |containerd|[containerd](https://containerd.io/) + [nerdctl](https://github.com/containerd/nerdctl) (run opctl with `--container-runtime containerd`)|
     |qemu (experimental)|[lima](https://github.com/lima-vm/lima/releases/latest)|
+
+    The `containerd` runtime drives containerd via the `nerdctl` CLI. Use it when you
+    need per-registry mirrors (e.g. to transparently redirect Docker Hub **and** Quay
+    pulls through a pull-through cache), which the Docker daemon can't do. See
+    [the containerd runtime README](https://github.com/opctl/opctl/blob/main/sdks/go/node/containerruntime/containerd/README.md)
+    for registry-mirror, auth, and proxy-bypass configuration.
 
     ## Installation
 


### PR DESCRIPTION
## What

Adds a new **`containerd`** container runtime to opctl, selected with `opctl --container-runtime containerd`. It drives containerd through the **`nerdctl`** CLI. The default runtime stays `docker`, so this is fully opt-in — the flag value *is* the feature flag, and existing dockerd-based nodes/jobs are untouched.

## Why

opctl's container-running backends are otherwise locked to the Docker Engine API (`docker` → hardcoded socket; `embedded` → a Lima VM running *dockerd*, with containerd explicitly disabled; `k8s` → the K8s API). The Docker daemon's `registry-mirrors` only mirrors **Docker Hub**, so it can't transparently redirect `quay.io` pulls.

containerd supports **per-registry mirrors** via `hosts.toml`, which lets Docker Hub **and** Quay pulls be redirected through a single ECR pull-through cache (PTC) with **no per-op image-ref changes**. The driving use case is Remitly's CodeBuild GHA runners, which sit behind a mandatory forward proxy and must pull op images through the PTC instead of Docker Hub / Quay.

Rather than reimplement containerd's gRPC API + CNI + snapshotter + resolver, the backend shells out to `nerdctl` (mirroring the existing `embedded` backend's shell-out pattern). nerdctl natively honors `/etc/containerd/certs.d/*/hosts.toml` mirrors and `~/.docker/config.json` credential helpers, which is exactly what makes transparent mirroring + ECR auth work.

## What's included

- **Backend** (`sdks/go/node/containerruntime/containerd/`): full `RunContainer` lifecycle (ensure network → pull/load image → create → start → stream stdout/stderr → register named-container DNS → wait/exit code → cleanup), plus `Delete`/`Kill`/`DeleteContainerIfExists`. Image pull keeps the docker backend's "skip cached non-`latest`" optimization; `image.src` is supported via OCI-archive → `nerdctl load`.
- **CLI wiring**: `containerd` branch in `getContainerRuntime.go`, flag help updated in `root.go`.
- **Tests**: `constructCreateArgs` (arg ordering, proxy-env propagation/no-clobber, mounts/ports/sockets) and helpers. `go test`/`vet`/`gofmt` green.
- **Docs/config**: package `README.md` (ECR auth-refresh mechanism + proxy-bypass requirement), `setup.md` row, CHANGELOG entry, and ready-to-copy `examples/` (`certs.d/{docker.io,quay.io}/hosts.toml`, `docker-config.json`, `containerd-config.toml`, `containerd.service.d/http-proxy.conf`, `iam-policy.json`).

## Reviewer notes

- **Behavioral difference from the docker backend (by design):** registry auth is resolved by containerd/nerdctl host config (e.g. `docker-credential-ecr-login`), **not** per-op `image.pullCreds`. GPU passthrough auto-detection is not implemented. Both are documented in the README.
- **Runner wiring lives elsewhere:** the CodeBuild runner template, IAM attachment, and host config belong in `Remitly/codebuild-infra-pipeline` (`runners/default/cfn/gha-codebuild-runner.yaml`). The configs/IAM here are meant to be lifted into a separate, reviewable PR there per the golden-pipeline sign-off norm.
- **Definition-of-done verification** (Hub + Quay ops pull through the PTC; new `docker-hub/…` and `quay/…` repos appear in the artifact-archive ECR; no runner egress to registry-1.docker.io / quay.io) requires an actual configured runner and is not exercised by CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)